### PR TITLE
Geojson Parser

### DIFF
--- a/encoding/error.go
+++ b/encoding/error.go
@@ -1,1 +1,23 @@
 package encoding
+
+import (
+	"fmt"
+
+	"github.com/go-spatial/geom"
+)
+
+type ErrUnknownGeometry struct {
+	Geom geom.Geometry
+}
+
+type ErrInvalidGeoJSON struct {
+	GJSON []byte
+}
+
+func (e ErrUnknownGeometry) Error() string {
+	return fmt.Sprintf("unknown geometry: %T", e.Geom)
+}
+
+func (e ErrInvalidGeoJSON) Error() string {
+	return fmt.Sprintf("Invalid GeoJSON string: %T", string(e.GJSON))
+}

--- a/encoding/geojson/geojson.go
+++ b/encoding/geojson/geojson.go
@@ -106,7 +106,7 @@ func (geo Geometry) MarshalJSON() ([]byte, error) {
 type featureType GeoJSONType
 
 func (_ featureType) MarshalJSON() ([]byte, error) {
-	return []byte(FeatureType), nil
+	return []byte(`"Feature"`), nil
 }
 
 type Feature struct {
@@ -123,7 +123,7 @@ type Feature struct {
 type featureCollectionType GeoJSONType
 
 func (_ featureCollectionType) MarshalJSON() ([]byte, error) {
-	return []byte(FeatureCollectionType), nil
+	return []byte(`"FeatureCollection"`), nil
 }
 
 type FeatureCollection struct {

--- a/encoding/geojson/geojson.go
+++ b/encoding/geojson/geojson.go
@@ -106,7 +106,7 @@ func (geo Geometry) MarshalJSON() ([]byte, error) {
 type featureType GeoJSONType
 
 func (_ featureType) MarshalJSON() ([]byte, error) {
-	return []byte(`"Feature"`), nil
+	return []byte(FeatureType), nil
 }
 
 type Feature struct {
@@ -120,7 +120,7 @@ type Feature struct {
 
 // featureCollectionType allows the GeoJSON type for Feature to be automatically set during json Marshalling
 // which avoids the user from accidentally setting the incorrect GeoJSON type.
-type featureCollectionType struct{}
+type featureCollectionType GeoJSONType
 
 func (_ featureCollectionType) MarshalJSON() ([]byte, error) {
 	return []byte(FeatureCollectionType), nil
@@ -225,6 +225,13 @@ func (geo *Geometry) UnmarshalJSON(b []byte) error {
 			return err
 		}
 		geo.Geometry = f
+	case FeatureCollectionType:
+		fc := FeatureCollection{}
+		err = json.Unmarshal(b, &fc)
+		if err != nil {
+			return err
+		}
+		geo.Geometry = fc
 	default:
 		return encoding.ErrInvalidGeoJSON{b}
 	}

--- a/encoding/geojson/geojson.go
+++ b/encoding/geojson/geojson.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/go-spatial/geom"
+	"github.com/go-spatial/geom/encoding"
 )
 
 type GeoJSONType string
@@ -16,6 +17,8 @@ const (
 	PolygonType            GeoJSONType = "Polygon"
 	MultiPolygonType       GeoJSONType = "MultiPolygon"
 	GeometryCollectionType GeoJSONType = "GeometryCollection"
+	FeatureType            GeoJSONType = "Feature"
+	FeatureCollectionType  GeoJSONType = "FeatureCollection"
 )
 
 type Geometry struct {
@@ -100,7 +103,7 @@ func (geo Geometry) MarshalJSON() ([]byte, error) {
 
 // featureType allows the GeoJSON type for Feature to be automatically set during json Marshalling
 // which avoids the user from accidentally setting the incorrect GeoJSON type.
-type featureType struct{}
+type featureType GeoJSONType
 
 func (_ featureType) MarshalJSON() ([]byte, error) {
 	return []byte(`"Feature"`), nil
@@ -120,7 +123,7 @@ type Feature struct {
 type featureCollectionType struct{}
 
 func (_ featureCollectionType) MarshalJSON() ([]byte, error) {
-	return []byte(`"FeatureCollection"`), nil
+	return []byte(FeatureCollectionType), nil
 }
 
 type FeatureCollection struct {
@@ -140,4 +143,90 @@ func closePolygon(p geom.Polygon) {
 			p[i] = append(p[i], p[i][0])
 		}
 	}
+}
+
+func (geo *Geometry) UnmarshalJSON(b []byte) error {
+	var geojsonMap map[string]*json.RawMessage
+	err := json.Unmarshal(b, &geojsonMap)
+	if err != nil {
+		return err
+	}
+
+	var geomType GeoJSONType
+	err = json.Unmarshal(*geojsonMap["type"], &geomType)
+	if err != nil {
+		return err
+	}
+	switch geomType {
+	case PointType:
+		var pt geom.Point
+		err = json.Unmarshal(*geojsonMap["coordinates"], &pt)
+		if err != nil {
+			return err
+		}
+		geo.Geometry = pt
+	case PolygonType:
+		var poly geom.Polygon
+		err = json.Unmarshal(*geojsonMap["coordinates"], &poly)
+		if err != nil {
+			return err
+		}
+		geo.Geometry = poly
+	case LineStringType:
+		var ls geom.LineString
+		err = json.Unmarshal(*geojsonMap["coordinates"], &ls)
+		if err != nil {
+			return err
+		}
+		geo.Geometry = ls
+	case MultiPointType:
+		var mp geom.MultiPoint
+		err = json.Unmarshal(*geojsonMap["coordinates"], &mp)
+		if err != nil {
+			return err
+		}
+		geo.Geometry = mp
+	case MultiLineStringType:
+		var ml geom.MultiLineString
+		err = json.Unmarshal(*geojsonMap["coordinates"], &ml)
+		if err != nil {
+			return err
+		}
+		geo.Geometry = ml
+	case MultiPolygonType:
+		var mp geom.MultiPolygon
+		err = json.Unmarshal(*geojsonMap["coordinates"], &mp)
+		if err != nil {
+			return err
+		}
+		geo.Geometry = mp
+	case GeometryCollectionType:
+		gc := geom.Collection{}
+		var rawMessageForGeometries []*json.RawMessage
+		err = json.Unmarshal(*geojsonMap["geometries"], &rawMessageForGeometries)
+		if err != nil {
+			return err
+		}
+		geoms := make([]geom.Geometry, len(rawMessageForGeometries))
+		for i, v := range rawMessageForGeometries {
+			var g Geometry
+			err = json.Unmarshal(*v, &g)
+			if err != nil {
+				return err
+			}
+			geoms[i] = g.Geometry
+		}
+		gc.SetGeometries(geoms)
+		geo.Geometry = gc
+	case FeatureType:
+		f := Feature{}
+		err = json.Unmarshal(b, &f)
+		if err != nil {
+			return err
+		}
+		geo.Geometry = f
+	default:
+		return encoding.ErrInvalidGeoJSON{b}
+	}
+	return nil
 }

--- a/encoding/geojson/geojson_test.go
+++ b/encoding/geojson/geojson_test.go
@@ -17,7 +17,7 @@ func TestFeatureMarshalJSON(t *testing.T) {
 	}
 
 	fn := func(t *testing.T, tc tcase) {
-		t.Parallel()
+		// t.Parallel()
 
 		f := geojson.Feature{
 			Geometry: geojson.Geometry{tc.geom},

--- a/encoding/geojson/geojson_test.go
+++ b/encoding/geojson/geojson_test.go
@@ -202,6 +202,13 @@ func TestUnmarshalJSON(t *testing.T) {
 				Geometry: geojson.Geometry{geom.Point{12.2, 17.7}},
 			},
 		},
+		"feature collection": {
+			gjson: []byte(`{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[12.2,17.7]},"properties":null}]}`),
+			expected: geojson.FeatureCollection{
+				Type:     "FeatureCollection",
+				Features: []geojson.Feature{geojson.Feature{Type: "Feature", Geometry: geojson.Geometry{geom.Point{12.2, 17.7}}}},
+			},
+		},
 	}
 
 	fn := func(t *testing.T, tc tcase) {

--- a/encoding/geojson/geojson_test.go
+++ b/encoding/geojson/geojson_test.go
@@ -118,3 +118,109 @@ func TestFeatureMarshalJSON(t *testing.T) {
 		t.Run(name, func(t *testing.T) { fn(t, tc) })
 	}
 }
+
+func TestUnmarshalJSON(t *testing.T) {
+	type tcase struct {
+		gjson       []byte
+		expected    geom.Geometry
+		expectedErr json.InvalidUnmarshalError
+	}
+
+	tests := map[string]tcase{
+		"point": {
+			gjson:    []byte(`{"type":"Point","coordinates":[12.2,17.7]}`),
+			expected: geom.Point{12.2, 17.7},
+		},
+		"multi point": {
+			gjson:    []byte(`{"type":"MultiPoint","coordinates":[[12.2,17.7],[13.3,18.8]]}`),
+			expected: geom.MultiPoint{{12.2, 17.7}, {13.3, 18.8}},
+		},
+		"linestring": {
+			gjson:    []byte(`{"type":"LineString","coordinates":[[3.2,4.3],[5.4,6.5],[7.6,8.7],[9.8,10.9]]}`),
+			expected: geom.LineString{geom.Point{3.2, 4.3}, geom.Point{5.4, 6.5}, geom.Point{7.6, 8.7}, geom.Point{9.8, 10.9}},
+		},
+		"multi linestring": {
+			gjson: []byte(`{"type":"MultiLineString","coordinates":[[[3.2,4.3],[5.4,6.5],[7.6,8.7],[9.8,10.9]],[[2.3,3.4],[4.5,5.6],[6.7,7.8],[8.9,9.1]],[[2.2,3.3],[4.4,5.5],[6.6,7.7],[8.8,9.9]]]}`),
+			expected: geom.MultiLineString{
+				{geom.Point{3.2, 4.3}, geom.Point{5.4, 6.5}, geom.Point{7.6, 8.7}, geom.Point{9.8, 10.9}},
+				{geom.Point{2.3, 3.4}, geom.Point{4.5, 5.6}, geom.Point{6.7, 7.8}, geom.Point{8.9, 9.10}},
+				{geom.Point{2.2, 3.3}, geom.Point{4.4, 5.5}, geom.Point{6.6, 7.7}, geom.Point{8.8, 9.9}},
+			},
+		},
+		"polygon": {
+			gjson: []byte(`{"type":"Polygon","coordinates":[[[3.2,4.3],[5.4,6.5],[7.6,8.7],[9.8,10.9],[3.2,4.3]]]}`),
+			expected: geom.Polygon{
+				{
+					geom.Point{3.2, 4.3}, geom.Point{5.4, 6.5}, geom.Point{7.6, 8.7}, geom.Point{9.8, 10.9}, geom.Point{3.2, 4.3},
+				},
+			},
+		},
+		"multi polygon": {
+			gjson: []byte(`{"type":"MultiPolygon","coordinates":[[[[10.1,10.1],[5.5,20.2],[7.7,30.3],[30.3,30.3],[30.3,10.1],[10.1,10.1]],[[15.5,15.5],[11.1,14.4],[11.1,11.1],[15.5,11.1],[15.5,15.5]],[[25.5,25.5],[21.1,24.4],[21.1,21.1],[25.5,21.1],[25.5,25.5]]],[[[75.5,75.5],[71.1,74.4],[71.1,71.1],[75.5,71.1],[75.5,75.5]]]]}`),
+			expected: geom.MultiPolygon{
+				// Polygon 1 w/ holes
+				geom.Polygon{
+					// Outer ring
+					{
+						geom.Point{10.1, 10.1},
+						geom.Point{5.5, 20.2},
+						geom.Point{7.7, 30.3},
+						geom.Point{30.3, 30.3},
+						geom.Point{30.3, 10.1},
+						geom.Point{10.1, 10.1},
+					},
+					// Hole 1
+					{
+						geom.Point{15.5, 15.5}, geom.Point{11.1, 14.4}, geom.Point{11.1, 11.1}, geom.Point{15.5, 11.1}, geom.Point{15.5, 15.5},
+					},
+					// Hole 2
+					{
+						geom.Point{25.5, 25.5}, geom.Point{21.1, 24.4}, geom.Point{21.1, 21.1}, geom.Point{25.5, 21.1}, geom.Point{25.5, 25.5},
+					},
+				},
+				// Polygon 2, simple
+				geom.Polygon{
+					// Hole 2
+					{
+						geom.Point{75.5, 75.5}, geom.Point{71.1, 74.4}, geom.Point{71.1, 71.1}, geom.Point{75.5, 71.1}, geom.Point{75.5, 75.5},
+					},
+				},
+			},
+		},
+		"geometry collection": {
+			gjson: []byte(`{"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[12.2,17.7]},{"type":"MultiPoint","coordinates":[[12.2,17.7],[13.3,18.8]]},{"type":"LineString","coordinates":[[3.2,4.3],[5.4,6.5],[7.6,8.7],[9.8,10.9]]}]}`),
+			expected: geom.Collection{
+				geom.Point{12.2, 17.7},
+				geom.MultiPoint{{12.2, 17.7}, {13.3, 18.8}},
+				geom.LineString{{3.2, 4.3}, {5.4, 6.5}, {7.6, 8.7}, {9.8, 10.9}},
+			},
+		},
+		"feature": {
+			gjson: []byte(`{"type":"Feature","geometry":{"type":"Point","coordinates":[12.2,17.7]},"properties":null}`),
+			expected: geojson.Feature{
+				Type:     "Feature",
+				Geometry: geojson.Geometry{geom.Point{12.2, 17.7}},
+			},
+		},
+	}
+
+	fn := func(t *testing.T, tc tcase) {
+		t.Parallel()
+
+		var output geojson.Geometry
+		err := json.Unmarshal(tc.gjson, &output)
+		if err != nil && err.Error() != tc.expectedErr.Error() {
+			t.Errorf("%s expected err %v got %v", t.Name(), tc.expectedErr.Error(), err)
+			return
+		}
+
+		if !reflect.DeepEqual(tc.expected, output.Geometry) {
+			t.Errorf("expected %v got %v", tc.expected, output.Geometry)
+			return
+		}
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) { fn(t, tc) })
+	}
+}


### PR DESCRIPTION
An initial pass at GeoJSON parser. There are few changes that needed to be made because they were solutions for writing only. The `Type` field in the Feature struct for example needs to be of type `string` or alias `string`.