### PR TITLE
Move spherical functions  (Segment/Extent and Hull) to new package

### DIFF
--- a/bbox.go
+++ b/bbox.go
@@ -158,37 +158,6 @@ func (e *Extent) Area() float64 {
 	return math.Abs((e.MaxY() - e.MinY()) * (e.MaxX() - e.MinX()))
 }
 
-// Hull returns the smallest extent from lon/lat points.
-// The hull is defined in the following order [4]float64{ West, South, East, North}
-func Hull(a, b [2]float64) *Extent {
-	// lat <=> y
-	// lng <=> x
-
-	// make a the westmost point
-	if math.Abs(a[0]-b[0]) > 180.0 {
-		// smallest longitudinal arc crosses the antimeridian
-		if a[0] < b[0] {
-			a[0], b[0] = b[0], a[0]
-		}
-	} else {
-		if a[0] > b[0] {
-			a[0], b[0] = b[0], a[0]
-		}
-	}
-
-	return Segment(a, b)
-}
-
-// Segment of a sphere from two long/lat points, with a being the westmost point and b the eastmost point; in following format [4]float64{ West, South, East, North }
-func Segment(westy, easty [2]float64) *Extent {
-	north, south := westy[1], easty[1]
-	if north < south {
-		south, north = north, south
-	}
-
-	return &Extent{westy[0], south, easty[0], north}
-}
-
 // NewExtent returns an Extent for the provided points; in following format [4]float64{ MinX, MinY, MaxX, MaxY }
 func NewExtent(points ...[2]float64) *Extent {
 	var xy [2]float64

--- a/spherical/extent.go
+++ b/spherical/extent.go
@@ -6,8 +6,8 @@ import (
 	"github.com/go-spatial/geom"
 )
 
-// Hull returns the smallest extent from lon/lat points.
-// The hull is defined in the following order [4]float64{ West, South, East, North}
+// Hull returns the smallest region of a sphere taking into account the antimeridian.
+// the hull is defined as a set of long/lat points in the following order [4]float64{ West, South, East, North}.
 func Hull(a, b [2]float64) *geom.Extent {
 	// lat <=> y
 	// lng <=> x
@@ -27,7 +27,8 @@ func Hull(a, b [2]float64) *geom.Extent {
 	return Extent(a, b)
 }
 
-// Segment of a sphere from two long/lat points, with a being the westmost point and b the eastmost point; in following format [4]float64{ West, South, East, North }
+// Extent is an explicit definition of a region of a sphere without taking into account the antimeridian.
+// The extent is a segment of a sphere from two long/lat points, with the first point being the westmost point and the second being the eastmost point; in following format [4]float64{ West, South, East, North }.
 func Extent(westy, easty [2]float64) *geom.Extent {
 	north, south := westy[1], easty[1]
 	if north < south {

--- a/spherical/extent.go
+++ b/spherical/extent.go
@@ -1,0 +1,38 @@
+package spherical
+
+import (
+	"math"
+
+	"github.com/go-spatial/geom"
+)
+
+// Hull returns the smallest extent from lon/lat points.
+// The hull is defined in the following order [4]float64{ West, South, East, North}
+func Hull(a, b [2]float64) *geom.Extent {
+	// lat <=> y
+	// lng <=> x
+
+	// make a the westmost point
+	if math.Abs(a[0]-b[0]) > 180.0 {
+		// smallest longitudinal arc crosses the antimeridian
+		if a[0] < b[0] {
+			a[0], b[0] = b[0], a[0]
+		}
+	} else {
+		if a[0] > b[0] {
+			a[0], b[0] = b[0], a[0]
+		}
+	}
+
+	return Extent(a, b)
+}
+
+// Segment of a sphere from two long/lat points, with a being the westmost point and b the eastmost point; in following format [4]float64{ West, South, East, North }
+func Extent(westy, easty [2]float64) *geom.Extent {
+	north, south := westy[1], easty[1]
+	if north < south {
+		south, north = north, south
+	}
+
+	return &geom.Extent{westy[0], south, easty[0], north}
+}


### PR DESCRIPTION
Creating a new spherical package makes clear that these functions operate on spherical coordinates rather than cartesian.