### PR TITLE
mvt: removing tegola artifacts and adding docs

### DIFF
--- a/encoding/mvt/README.md
+++ b/encoding/mvt/README.md
@@ -10,20 +10,24 @@ In short, a `Tile`s has `Layer`s, which have `Feauture`s. The `Feature` type
 is what holds a single `geom.Geometry` and associated metadata.
 
 To encode a geometry into a tile, you need:
-* a geometry
-* a tile's `geom.Extent` in the same projection as the geometry
-* the size of the tile you want to output in pixels
+  * a geometry
+  * a tile's `geom.Extent` in the same projection as the geometry
+  * the size of the tile you want to output in pixels
+
+**note**: the geometry must not go outside the tile extent. If this is unknown,
+use the [clip package](https://godoc.org/github.com/go-spatial/geom/planar/clip#Geometry)
+before encoding.
 
 To encode:
-1. Call `PrepareGeomtry`, it returns a `geom.Geometry` that is "reprojected"
-   into pixel values relative to the tile
-2. Add the returned geometry to a `Feature`, optionally with an ID and
-   tags by calling `NewFeatures`.
-3. Add the feature to a `Layer` with a name for the layer
-   by calling `(*Layer).AddFeatures`
-4. Add the layer to a `Tile` by calling `(*Tile).AddLayers`
-5. Get the `protobuf` tile by calling `(*Tile).VTile`
-6. Encode the `protobuf` into bytes with `proto.Marshal`
+  1. Call `PrepareGeomtry`, it returns a `geom.Geometry` that is "reprojected"
+     into pixel values relative to the tile
+  2. Add the returned geometry to a `Feature`, optionally with an ID and
+     tags by calling `NewFeatures`.
+  3. Add the feature to a `Layer` with a name for the layer
+     by calling `(*Layer).AddFeatures`
+  4. Add the layer to a `Tile` by calling `(*Tile).AddLayers`
+  5. Get the `protobuf` tile by calling `(*Tile).VTile`
+  6. Encode the `protobuf` into bytes with `proto.Marshal`
 
 For an example, check the use of this package in [tegola/atlas/map.go](https://github.com/go-spatial/tegola/blob/master/atlas/map.go)
 

--- a/encoding/mvt/README.md
+++ b/encoding/mvt/README.md
@@ -1,0 +1,29 @@
+# MVT
+
+[![GoDoc](https://godoc.org/github.com/go-spatial/geom/encoding/mvt?status.svg)](https://godoc.org/github.com/go-spatial/geom/encoding/mvt)
+
+This package contains functions and types for encoding a geometry in
+[Mapbox Vector Tiles](https://github.com/mapbox/vector-tile-spec). This
+package depends on the [protbuf](https://github.com/golang/protobuf) package.
+
+In short, a `Tile`s has `Layer`s, which have `Feauture`s. The `Feature` type
+is what holds a single `geom.Geometry` and associated metadata.
+
+To encode a geometry into a tile, you need:
+* a geometry
+* a tile's `geom.Extent` in the same projection as the geometry
+* the size of the tile you want to output in pixels
+
+To encode:
+1. Call `PrepareGeomtry`, it returns a `geom.Geometry` that is "reprojected"
+   into pixel values relative to the tile
+2. Add the returned geometry to a `Feature`, optionally with an ID and
+   tags by calling `NewFeatures`.
+3. Add the feature to a `Layer` with a name for the layer
+   by calling `(*Layer).AddFeatures`
+4. Add the layer to a `Tile` by calling `(*Tile).AddLayers`
+5. Get the `protobuf` tile by calling `(*Tile).VTile`
+6. Encode the `protobuf` into bytes with `proto.Marshal`
+
+For an example, check the use of this package in [tegola/atlas/map.go](https://github.com/go-spatial/tegola/blob/master/atlas/map.go)
+

--- a/encoding/mvt/mvt.go
+++ b/encoding/mvt/mvt.go
@@ -1,4 +1,6 @@
 /*
+Package mvt is used to encode MVT tiles
+
 In short, a `Tile`s has `Layer`s, which have `Feauture`s. The `Feature` type
 is what holds a single `geom.Geometry` and associated metadata.
 

--- a/encoding/mvt/mvt.go
+++ b/encoding/mvt/mvt.go
@@ -1,3 +1,30 @@
+/*
+In short, a `Tile`s has `Layer`s, which have `Feauture`s. The `Feature` type
+is what holds a single `geom.Geometry` and associated metadata.
+
+To encode a geometry into a tile, you need:
+	* a geometry
+	* a tile's `geom.Extent` in the same projection as the geometry
+	* the size of the tile you want to output in pixels
+
+note: the geometry must not go outside the tile extent. If this is unknown,
+use the clip package before encoding.
+(https://godoc.org/github.com/go-spatial/geom/planar/clip#Geometry)
+
+
+To encode:
+	1. Call `PrepareGeomtry`, it returns a `geom.Geometry` that is "reprojected"
+	   into pixel values relative to the tile
+	2. Add the returned geometry to a `Feature`, optionally with an ID and
+	   tags by calling `NewFeatures`.
+	3. Add the feature to a `Layer` with a name for the layer
+	   by calling `(*Layer).AddFeatures`
+	4. Add the layer to a `Tile` by calling `(*Tile).AddLayers`
+	5. Get the `protobuf` tile by calling `(*Tile).VTile`
+	6. Encode the `protobuf` into bytes with `proto.Marshal`
+
+For an example, check the use of this package in tegola/atlas/map.go (https://github.com/go-spatial/tegola/blob/master/atlas/map.go)
+*/
 package mvt
 
 const (

--- a/encoding/mvt/prepare.go
+++ b/encoding/mvt/prepare.go
@@ -6,12 +6,11 @@ import (
 	"github.com/go-spatial/geom"
 )
 
-// A default valu for pixelExtent for use with PrepareGeo
-const DefaultPixelExtent = 4096.0
-
 // PrepareGeo converts the geometry's coordinates to tile coordinates. tile should be the
 // extent of the tile, in the same projection as geo. pixelExtent is the dimension of the
-// (square) tile in pixels usually 4096, see DefaultPixelExtent)
+// (square) tile in pixels usually 4096, see DefaultExtent.
+// The geometry must not go outside the tile extent. If this is unknown,
+// use the clip package before encoding.
 func PrepareGeo(geo geom.Geometry, tile *geom.Extent, pixelExtent float64) geom.Geometry {
 	switch g := geo.(type) {
 	case geom.Point:

--- a/encoding/mvt/prepare_internal_test.go
+++ b/encoding/mvt/prepare_internal_test.go
@@ -17,7 +17,7 @@ func TestPrepareLinestring(t *testing.T) {
 
 	fn := func(tc tcase) func(t *testing.T) {
 		return func(t *testing.T) {
-			got := preparelinestr(tc.in, &tc.tile, DefaultPixelExtent)
+			got := preparelinestr(tc.in, &tc.tile, float64(DefaultExtent))
 
 			if len(got) != len(tc.out) {
 				t.Errorf("expected %v got %v", tc.out, got)


### PR DESCRIPTION
I removed `tegola.Tile` from the function signature. The encoding function now takes an `geom.Extent` that is used to represent the extent of a tile. It also takes the size of the ouput tile in pixels.

This approach makes it so the encoder does not have to worry about the `geom.Geometry`'s SRID. The passed in `geom.Extent` is expected to be in the same projection as the `geom.Geometry.

*Todo*: I need to add a comment in `PrepareGeo`, I'm not sure what happens when the geometry goes outside the tile. Are geometries allowed outside of the tile?