### PR TITLE
cmp: more accurate handling of large and small numbers

### DIFF
--- a/circle_test.go
+++ b/circle_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/go-spatial/geom/cmp"
 )
 
-const tolerance = geom.TOLERANCE
+const tolerance = geom.Tolerance
+const bitTolerance = geom.BitTolerance
 
 func TestCircleFromPoints(t *testing.T) {
 	type tcase struct {
@@ -28,17 +29,17 @@ func TestCircleFromPoints(t *testing.T) {
 			return
 		}
 
-		if !cmp.Float64(circle.Radius, tc.circle.Radius, tolerance) {
+		if !cmp.Float64(circle.Radius, tc.circle.Radius, tolerance, bitTolerance) {
 			t.Errorf("circle radius, expected %v got %v", tc.circle, circle)
 			return
 		}
 
-		if !cmp.Float64(circle.Center[0], tc.circle.Center[0], tolerance) {
+		if !cmp.Float64(circle.Center[0], tc.circle.Center[0], tolerance, bitTolerance) {
 			t.Errorf("circle x, expected %v got %v", tc.circle, circle)
 			return
 		}
 
-		if !cmp.Float64(circle.Center[1], tc.circle.Center[1], tolerance) {
+		if !cmp.Float64(circle.Center[1], tc.circle.Center[1], tolerance, bitTolerance) {
 			t.Errorf("circle y, expected %v got %v", tc.circle, circle)
 			return
 		}

--- a/cmp/cmp.go
+++ b/cmp/cmp.go
@@ -11,7 +11,7 @@ import (
 const Tolerance = 0.000001
 
 // BitTolerance is the epsilon value for comaparing float bit-patterns.
-// It was calculated as math.Float64Bbits(1.000001) - math.Float64bits(1.0)
+// It was calculated as math.Float64bits(1.000001) - math.Float64bits(1.0)
 const BitTolerance = 4503599627
 
 var (
@@ -69,9 +69,8 @@ func Float64(f1, f2, tolerance float64, bitTolerance int64) bool {
 
 	if d < 0 {
 		return d > -bitTolerance
-	} else {
-		return d < bitTolerance
 	}
+	return d < bitTolerance
 }
 
 // Float compares two floats to see if they are within 0.00001 from each other. This is the best way to compare floats.

--- a/cmp/cmp.go
+++ b/cmp/cmp.go
@@ -7,8 +7,12 @@ import (
 	"github.com/go-spatial/geom"
 )
 
-// TOLERANCE is the epsilon value used in comparing floats.
-const TOLERANCE = 0.000001
+// Tolerance is the epsilon value used in comparing floats with zero
+const Tolerance = 0.000001
+
+// BitTolerance is the epsilon value for comaparing float bit-patterns.
+// It was calculated as math.Float64Bbits(1.000001) - math.Float64bits(1.0)
+const BitTolerance = 4503599627
 
 var (
 	NilPoint           = (*geom.Point)(nil)
@@ -21,10 +25,10 @@ var (
 )
 
 // FloatSlice compare two sets of float slices.
-func FloatSlice(f1, f2 []float64) bool { return Float64Slice(f1, f2, TOLERANCE) }
+func FloatSlice(f1, f2 []float64) bool { return Float64Slice(f1, f2, Tolerance, BitTolerance) }
 
 // Float64Slice compares two sets of float64 slices within the given tolerance.
-func Float64Slice(f1, f2 []float64, tolerance float64) bool {
+func Float64Slice(f1, f2 []float64, tolerance float64, bitTolerance int64) bool {
 	if len(f1) != len(f2) {
 		return false
 	}
@@ -38,7 +42,7 @@ func Float64Slice(f1, f2 []float64, tolerance float64) bool {
 	sort.Float64s(f1s)
 	sort.Float64s(f2s)
 	for i := range f1s {
-		if !Float64(f1s[i], f2s[i], tolerance) {
+		if !Float64(f1s[i], f2s[i], tolerance, bitTolerance) {
 			return false
 		}
 	}
@@ -46,24 +50,32 @@ func Float64Slice(f1, f2 []float64, tolerance float64) bool {
 }
 
 // Float64 compares two floats to see if they are within the given tolerance.
-func Float64(f1, f2, tolerance float64) bool {
-	if math.IsInf(f1, 1) {
-		return math.IsInf(f2, 1)
+func Float64(f1, f2, tolerance float64, bitTolerance int64) bool {
+
+	// handle infinity
+	if math.IsInf(f1, 0) || math.IsInf(f2, 0) {
+		return math.IsInf(f1, -1) == math.IsInf(f2, -1) &&
+			math.IsInf(f1, 1) == math.IsInf(f2, 1)
 	}
-	if math.IsInf(f2, 1) {
-		return math.IsInf(f1, 1)
+
+	// -0.0 exist but -0.0 == 0.0 is true
+	if f1 == 0 || f2 == 0 {
+		return math.Abs(f2 - f1) < tolerance
 	}
-	if math.IsInf(f1, -1) {
-		return math.IsInf(f2, -1)
+
+	i1 := int64(math.Float64bits(f1))
+	i2 := int64(math.Float64bits(f2))
+	d := i2 - i1
+
+	if d < 0 {
+		return d > -bitTolerance
+	} else {
+		return d < bitTolerance
 	}
-	if math.IsInf(f2, -1) {
-		return math.IsInf(f1, -1)
-	}
-	return math.Abs(f1-f2) < tolerance
 }
 
 // Float compares two floats to see if they are within 0.00001 from each other. This is the best way to compare floats.
-func Float(f1, f2 float64) bool { return Float64(f1, f2, TOLERANCE) }
+func Float(f1, f2 float64) bool { return Float64(f1, f2, Tolerance, BitTolerance) }
 
 // Extent will check to see if the Extents's are the same.
 func Extent(extent1, extent2 [4]float64) bool {

--- a/geom.go
+++ b/geom.go
@@ -1,7 +1,8 @@
 // Package geom describes geometry interfaces.
 package geom
 
-const TOLERANCE = 0.000001
+const Tolerance = 0.000001
+const BitTolerance = 4503599627
 
 // Geometry is an object with a spatial reference.
 // if a method accepts a Geometry type it's only expected to support the geom types in this package

--- a/slippy/tile_test.go
+++ b/slippy/tile_test.go
@@ -1,6 +1,7 @@
 package slippy_test
 
 import (
+	"math"
 	"strconv"
 	"testing"
 
@@ -41,8 +42,9 @@ func TestNewTile(t *testing.T) {
 			}
 			{
 				bounds := tile.Extent4326()
+				bitTolerence2 := int64(math.Float64bits(1.01) - math.Float64bits(1.00))
 				for i := 0; i < 4; i++ {
-					if !cmp.Float64(bounds[i], tc.eBounds[i], 0.01) {
+					if !cmp.Float64(bounds[i], tc.eBounds[i], 0.01, bitTolerence2) {
 						t.Errorf("bounds[%v] , expected %v got %v", i, tc.eBounds[i], bounds[i])
 
 					}


### PR DESCRIPTION
* comparisons with zero are absoloute (epsilon method)
* comparisons with non-zeros are relative (bit pattern distance method)

I also renamed `TOLERANCE` to conform with Go conventions

performance difference (slower as expected)
```
name        old time/op    new time/op    delta
CmpFloat-4    4.89ms ± 1%    5.53ms ± 1%  +12.93%  (p=0.000 n=8+7)

name        old alloc/op   new alloc/op   delta
CmpFloat-4     66.7B ± 1%     75.1B ± 1%  +12.63%  (p=0.001 n=7+7)

name        old allocs/op  new allocs/op  delta
CmpFloat-4      0.00           0.00          ~     (all equal)
```