### PR TITLE
[encoding] revisions to WKT encode

### DIFF
--- a/cmp/empty.go
+++ b/cmp/empty.go
@@ -45,25 +45,58 @@ func IsEmptyGeo(geo geom.Geometry) (isEmpty bool, err error) {
 	case [2]float64:
 		return IsEmptyPoint(g), nil
 
-	case geom.Pointer:
+	case geom.Point:
+		return IsEmptyPoint(g.XY()), nil
+
+	case *geom.Point:
+		if g == nil {
+			return true, nil
+		}
+
 		return IsEmptyPoint(g.XY()), nil
 
 	case [][2]float64:
 		return IsEmptyPoints(g), nil
 
-	case geom.MultiPointer:
+	case geom.MultiPoint:
 		return IsEmptyPoints(g.Points()), nil
 
-	case geom.LineStringer:
+	case *geom.MultiPoint:
+		if g == nil {
+			return true, nil
+		}
+
+		return IsEmptyPoints(g.Points()), nil
+
+	case geom.LineString:
 		return IsEmptyPoints(g.Verticies()), nil
 
-	case geom.MultiLineStringer:
+	case *geom.LineString:
+		if g == nil {
+			return true, nil
+		}
+		return IsEmptyPoints(g.Verticies()), nil
+
+	case geom.MultiLineString:
 		return IsEmptyLines(g.LineStrings()), nil
 
-	case geom.Polygoner:
+	case *geom.MultiLineString:
+		if g == nil {
+			return true, nil
+		}
+		return IsEmptyLines(g.LineStrings()), nil
+
+
+	case geom.Polygon:
 		return IsEmptyLines(g.LinearRings()), nil
 
-	case geom.MultiPolygoner:
+	case *geom.Polygon:
+		if g == nil {
+			return true, nil
+		}
+		return IsEmptyLines(g.LinearRings()), nil
+
+	case geom.MultiPolygon:
 		for _, v := range g.Polygons() {
 			if !IsEmptyLines(v) {
 				return false, nil
@@ -72,7 +105,20 @@ func IsEmptyGeo(geo geom.Geometry) (isEmpty bool, err error) {
 
 		return true, nil
 
-	case geom.Collectioner:
+	case *geom.MultiPolygon:
+		if g == nil {
+			return true, nil
+		}
+
+		for _, v := range g.Polygons() {
+			if !IsEmptyLines(v) {
+				return false, nil
+			}
+		}
+
+		return true, nil
+
+	case geom.Collection:
 		for _, v := range g.Geometries() {
 			isEmpty, err := IsEmptyGeo(v)
 			if err != nil {
@@ -84,6 +130,24 @@ func IsEmptyGeo(geo geom.Geometry) (isEmpty bool, err error) {
 		}
 
 		return true, nil
+
+	case *geom.Collection:
+		if g == nil {
+			return true, nil
+		}
+
+		for _, v := range g.Geometries() {
+			isEmpty, err := IsEmptyGeo(v)
+			if err != nil {
+				return false, err
+			}
+			if !isEmpty {
+				return false, nil
+			}
+		}
+
+		return true, nil
+
 	default:
 		return false, fmt.Errorf("unknown geometry %T", geo)
 	}

--- a/cmp/empty.go
+++ b/cmp/empty.go
@@ -1,0 +1,90 @@
+package cmp
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/go-spatial/geom"
+)
+
+func IsEmptyPoint(pt [2]float64) bool {
+	return pt != pt
+}
+
+func IsEmptyPoints(pts [][2]float64) bool {
+	for _, v := range pts {
+		if !IsEmptyPoint(v) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func IsEmptyLines(lns [][][2]float64) bool {
+	for _, v := range lns {
+		if !IsEmptyPoints(v) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func IsNil(a interface{}) bool {
+	defer func() { recover() }()
+	return a == nil || reflect.ValueOf(a).IsNil()
+}
+
+func IsEmptyGeo(geo geom.Geometry) (isEmpty bool, err error) {
+	if IsNil(geo) {
+		return true, nil
+	}
+
+	switch g := geo.(type) {
+	case [2]float64:
+		return IsEmptyPoint(g), nil
+
+	case geom.Pointer:
+		return IsEmptyPoint(g.XY()), nil
+
+	case [][2]float64:
+		return IsEmptyPoints(g), nil
+
+	case geom.MultiPointer:
+		return IsEmptyPoints(g.Points()), nil
+
+	case geom.LineStringer:
+		return IsEmptyPoints(g.Verticies()), nil
+
+	case geom.MultiLineStringer:
+		return IsEmptyLines(g.LineStrings()), nil
+
+	case geom.Polygoner:
+		return IsEmptyLines(g.LinearRings()), nil
+
+	case geom.MultiPolygoner:
+		for _, v := range g.Polygons() {
+			if !IsEmptyLines(v) {
+				return false, nil
+			}
+		}
+
+		return true, nil
+
+	case geom.Collectioner:
+		for _, v := range g.Geometries() {
+			isEmpty, err := IsEmptyGeo(v)
+			if err != nil {
+				return false, err
+			}
+			if !isEmpty {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	default:
+		return false, fmt.Errorf("unknown geometry %T", geo)
+	}
+}

--- a/cmp/empty_test.go
+++ b/cmp/empty_test.go
@@ -1,0 +1,510 @@
+package cmp
+
+import (
+	"math"
+	"testing"
+
+	"github.com/go-spatial/geom"
+)
+
+func TestIsEmptyGeo(t *testing.T) {
+	type tcase struct {
+		geo     geom.Geometry
+		isEmpty bool
+		err     string
+	}
+
+	fn := func(tc tcase) func(t *testing.T) {
+		return func(t *testing.T) {
+			isEmpty, err := IsEmptyGeo(tc.geo)
+			if err != nil {
+				if err.Error() != tc.err {
+					t.Errorf("expected error %v, got %v", tc.err, err)
+				}
+				return
+			} else if tc.err != "" {
+				t.Errorf("expected error %v, got nil", tc.err)
+				return
+			}
+
+			if isEmpty != tc.isEmpty {
+				t.Errorf("expected isEmpty %v, got %v", tc.isEmpty, isEmpty)
+			}
+		}
+	}
+
+	tcases := map[string]tcase{
+		"point": {
+			geo:     geom.Point{},
+			isEmpty: false,
+		},
+		"empty point": {
+			geo:     geom.Point{math.NaN(), math.NaN()},
+			isEmpty: true,
+		},
+		"nil point": {
+			geo: (*geom.Point)(nil),
+			isEmpty: true,
+		},
+		"non-nil point": {
+			geo: &geom.Point{},
+			isEmpty: false,
+		},
+		"multipoint": {
+			geo: geom.MultiPoint{geom.Point{}},
+			isEmpty: false,
+		},
+		"empty multipoint": {
+			geo: geom.MultiPoint{},
+			isEmpty: true,
+		},
+		"empty multipoint 1": {
+			geo: geom.MultiPoint{geom.Point{math.NaN(), math.NaN()}},
+			isEmpty: true,
+		},
+		"non empty multipoint": {
+			geo: geom.MultiPoint{
+				{},
+				geom.Point{math.NaN(), math.NaN()},
+			},
+			isEmpty: false,
+		},
+		"nil multipoint": {
+			geo: (*geom.MultiPoint)(nil),
+			isEmpty: true,
+		},
+		"linestring": {
+			geo: geom.LineString{geom.Point{}},
+			isEmpty: false,
+		},
+		"empty linestring": {
+			geo: geom.LineString{},
+			isEmpty: true,
+		},
+		"empty linestring 1": {
+			geo: geom.LineString{geom.Point{math.NaN(), math.NaN()}},
+			isEmpty: true,
+		},
+		"non empty linestring": {
+			geo: geom.LineString{
+				{},
+				geom.Point{math.NaN(), math.NaN()},
+			},
+			isEmpty: false,
+		},
+		"nil linestring": {
+			geo: (*geom.LineString)(nil),
+			isEmpty: true,
+		},
+		"multilinestring": {
+			geo: geom.MultiLineString{
+				geom.LineString{
+					geom.Point{},
+				},
+			},
+			isEmpty: false,
+		},
+		"empty multilinestring": {
+			geo: geom.MultiLineString{},
+			isEmpty: true,
+		},
+		"empty multilinestring 1": {
+			geo: geom.MultiLineString{
+				geom.LineString{},
+			},
+			isEmpty: true,
+		},
+		"empty multilinestring 2": {
+			geo: geom.MultiLineString{
+				geom.LineString{
+					geom.Point{math.NaN(), math.NaN()},
+				},
+			},
+			isEmpty: true,
+		},
+		"empty multilinestring 3": {
+			geo: geom.MultiLineString{
+				geom.LineString{
+					geom.Point{math.NaN(), math.NaN()},
+					geom.Point{math.NaN(), math.NaN()},
+				},
+				geom.LineString{
+					geom.Point{math.NaN(), math.NaN()},
+					geom.Point{math.NaN(), math.NaN()},
+				},
+			},
+			isEmpty: true,
+		},
+		"non empty multilinestring": {
+			geo: geom.MultiLineString{
+				geom.LineString{
+					{},
+					geom.Point{math.NaN(), math.NaN()},
+				},
+			},
+			isEmpty: false,
+		},
+		"non empty multilinestring 1": {
+			geo: geom.MultiLineString{
+				geom.LineString{},
+				geom.LineString{
+					{},
+					geom.Point{math.NaN(), math.NaN()},
+				},
+			},
+			isEmpty: false,
+		},
+		"nil multilinestring": {
+			geo: (*geom.MultiLineString)(nil),
+			isEmpty: true,
+		},
+		"polygon": {
+			geo: geom.Polygon{
+				geom.LineString{
+					geom.Point{},
+				},
+			},
+			isEmpty: false,
+		},
+		"empty polygon": {
+			geo: geom.Polygon{},
+			isEmpty: true,
+		},
+		"empty polygon 1": {
+			geo: geom.Polygon{
+				geom.LineString{},
+			},
+			isEmpty: true,
+		},
+		"empty polygon 2": {
+			geo: geom.Polygon{
+				geom.LineString{
+					geom.Point{math.NaN(), math.NaN()},
+				},
+			},
+			isEmpty: true,
+		},
+		"empty polygon 3": {
+			geo: geom.Polygon{
+				geom.LineString{
+					geom.Point{math.NaN(), math.NaN()},
+					geom.Point{math.NaN(), math.NaN()},
+				},
+				geom.LineString{
+					geom.Point{math.NaN(), math.NaN()},
+					geom.Point{math.NaN(), math.NaN()},
+				},
+			},
+			isEmpty: true,
+		},
+		"non empty polygon": {
+			geo: geom.Polygon{
+				geom.LineString{
+					{},
+					geom.Point{math.NaN(), math.NaN()},
+				},
+			},
+			isEmpty: false,
+		},
+		"non empty polygon 1": {
+			geo: geom.Polygon{
+				geom.LineString{},
+				geom.LineString{
+					{},
+					geom.Point{math.NaN(), math.NaN()},
+				},
+			},
+			isEmpty: false,
+		},
+		"nil polygon": {
+			geo: (*geom.Polygon)(nil),
+			isEmpty: true,
+		},
+		"multipolygon": {
+			geo: geom.MultiPolygon{
+				geom.Polygon{
+					geom.LineString{
+						geom.Point{},
+					},
+				},
+			},
+			isEmpty: false,
+		},
+		"empty multipolygon": {
+			geo: geom.MultiPolygon{},
+			isEmpty: true,
+		},
+		"empty multipolygon 1": {
+			geo: geom.MultiPolygon{
+				geom.Polygon{
+					geom.LineString{},
+				},
+			},
+			isEmpty: true,
+		},
+		"empty multipolygon 2": {
+			geo: geom.MultiPolygon{
+				geom.Polygon{
+					geom.LineString{
+						geom.Point{math.NaN(), math.NaN()},
+					},
+				},
+			},
+			isEmpty: true,
+		},
+		"empty multipolygon 3": {
+			geo: geom.MultiPolygon{
+				geom.Polygon{
+					geom.LineString{
+						geom.Point{math.NaN(), math.NaN()},
+						geom.Point{math.NaN(), math.NaN()},
+					},
+					geom.LineString{
+						geom.Point{math.NaN(), math.NaN()},
+						geom.Point{math.NaN(), math.NaN()},
+					},
+				},
+			},
+			isEmpty: true,
+		},
+		"empty multipolygon 4": {
+			geo: geom.MultiPolygon{
+				geom.Polygon{
+					geom.LineString{
+						geom.Point{math.NaN(), math.NaN()},
+						geom.Point{math.NaN(), math.NaN()},
+					},
+					geom.LineString{
+						geom.Point{math.NaN(), math.NaN()},
+						geom.Point{math.NaN(), math.NaN()},
+					},
+				},
+				geom.Polygon{
+					geom.LineString{
+						geom.Point{math.NaN(), math.NaN()},
+						geom.Point{math.NaN(), math.NaN()},
+					},
+					geom.LineString{
+						geom.Point{math.NaN(), math.NaN()},
+						geom.Point{math.NaN(), math.NaN()},
+					},
+				},
+			},
+			isEmpty: true,
+		},
+		"non empty multipolygon": {
+			geo: geom.MultiPolygon{
+				geom.Polygon{
+					geom.LineString{
+						{},
+						geom.Point{math.NaN(), math.NaN()},
+					},
+				},
+			},
+			isEmpty: false,
+		},
+		"non empty multipolygon 1": {
+			geo: geom.MultiPolygon{
+				geom.Polygon{
+					geom.LineString{},
+					geom.LineString{
+						geom.Point{math.NaN(), math.NaN()},
+						{},
+					},
+				},
+			},
+			isEmpty: false,
+		},
+		"non empty multipolygon 2": {
+			geo: geom.MultiPolygon{
+				geom.Polygon{
+					geom.LineString{
+						geom.Point{math.NaN(), math.NaN()},
+						geom.Point{math.NaN(), math.NaN()},
+					},
+					geom.LineString{
+						geom.Point{math.NaN(), math.NaN()},
+						geom.Point{math.NaN(), math.NaN()},
+					},
+				},
+				geom.Polygon{
+					geom.LineString{},
+					geom.LineString{
+						geom.Point{math.NaN(), math.NaN()},
+						{},
+					},
+				},
+			},
+			isEmpty: false,
+		},
+		"nil multipolygon": {
+			geo: (*geom.Polygon)(nil),
+			isEmpty: true,
+		},
+		"collection": {
+			geo: geom.Collection{
+				geom.Point{},
+			},
+			isEmpty: false,
+		},
+		"empty collection": {
+			geo: geom.Collection{},
+			isEmpty: true,
+		},
+		"empty collection 1": {
+			geo: geom.Collection{
+				geom.Point{math.NaN(), math.NaN()},
+				geom.MultiPoint{},
+				geom.LineString{},
+				geom.MultiLineString{},
+				geom.Polygon{},
+				geom.MultiPolygon{},
+				geom.Collection{
+					geom.Point{math.NaN(), math.NaN()},
+				},
+			},
+			isEmpty: true,
+		},
+		"non-empty collection": {
+			geo: geom.Collection{
+				geom.Collection{},
+				geom.Collection{
+					geom.Point{},
+				},
+			},
+			isEmpty: false,
+		},
+		"non-empty collection 1": {
+			geo: geom.Collection{
+				geom.Point{math.NaN(), math.NaN()},
+				geom.MultiPoint{},
+				geom.LineString{},
+				geom.MultiLineString{},
+				geom.Polygon{},
+				geom.MultiPolygon{},
+				geom.Collection{
+					geom.Point{math.NaN(), math.NaN()},
+					geom.Point{},
+				},
+			},
+			isEmpty: false,
+		},
+		"nil collection": {
+			geo: (*geom.Collection)(nil),
+			isEmpty: true,
+		},
+		"type check": {
+			geo: int(0),
+			err: "unknown geometry int",
+		},
+		// non-nil pointers
+		"*point": {
+			geo: &geom.Point{},
+			isEmpty: false,
+		},
+		"empty *point": {
+			geo: &geom.Point{math.NaN(), math.NaN()},
+			isEmpty: true,
+		},
+		"*multipoint": {
+			geo: &geom.MultiPoint{
+				geom.Point{},
+			},
+			isEmpty: false,
+		},
+		"empty *multipoint": {
+			geo: &geom.MultiPoint{
+				geom.Point{math.NaN(), math.NaN()},
+			},
+			isEmpty: true,
+		},
+		"*linestring": {
+			geo: &geom.LineString{
+				geom.Point{},
+			},
+			isEmpty: false,
+		},
+		"empty *linestring": {
+			geo: &geom.LineString{
+				geom.Point{math.NaN(), math.NaN()},
+			},
+			isEmpty: true,
+		},
+		"*multilinestring": {
+			geo: &geom.MultiLineString{
+				geom.LineString{
+					geom.Point{},
+				},
+			},
+			isEmpty: false,
+		},
+		"empty *multilinestring": {
+			geo: &geom.MultiLineString{
+				geom.LineString{
+					geom.Point{math.NaN(), math.NaN()},
+				},
+			},
+			isEmpty: true,
+		},
+		"*polygon": {
+			geo: &geom.Polygon{
+				geom.LineString{
+					geom.Point{},
+				},
+			},
+			isEmpty: false,
+		},
+		"empty *polygon": {
+			geo: &geom.Polygon{
+				geom.LineString{
+					geom.Point{math.NaN(), math.NaN()},
+				},
+			},
+			isEmpty: true,
+		},
+		"*multipolygon": {
+			geo: &geom.MultiPolygon{
+				geom.Polygon{
+					geom.LineString{
+						geom.Point{},
+					},
+				},
+			},
+			isEmpty: false,
+		},
+		"empty *multipolygon": {
+			geo: &geom.MultiPolygon{
+				geom.Polygon{
+					geom.LineString{
+						geom.Point{math.NaN(), math.NaN()},
+					},
+				},
+			},
+			isEmpty: true,
+		},
+		"*collection": {
+			geo: &geom.Collection{
+				&geom.Polygon{
+					geom.LineString{
+						geom.Point{},
+					},
+				},
+			},
+			isEmpty: false,
+		},
+		"empty *collection": {
+			geo: &geom.Collection{
+				&geom.Polygon{
+					geom.LineString{
+						geom.Point{math.NaN(), math.NaN()},
+					},
+				},
+			},
+			isEmpty: true,
+		},
+	}
+
+	for k, v := range tcases {
+		t.Run(k, fn(v))
+	}
+}

--- a/encoding/wkt/wkt.go
+++ b/encoding/wkt/wkt.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Encode(w io.Writer, geo geom.Geometry) error {
-	return NewEncoder(w).Encode(geo)
+	return NewDefaultEncoder(w).Encode(geo)
 }
 
 func EncodeBytes(geo geom.Geometry) ([]byte, error) {

--- a/encoding/wkt/wkt.go
+++ b/encoding/wkt/wkt.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Encode(w io.Writer, geo geom.Geometry) error {
-	return NewEncoder(w).Encode(geo, true)
+	return NewEncoder(w).Encode(geo)
 }
 
 func EncodeBytes(geo geom.Geometry) ([]byte, error) {

--- a/encoding/wkt/wkt_decode.go
+++ b/encoding/wkt/wkt_decode.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"unicode"
 
 	"github.com/go-spatial/geom"
 	"github.com/go-spatial/geom/cmp"
@@ -48,19 +49,10 @@ func (d *Decoder) unreadByte() error {
 // readWhitespace eats up the whitespace and returns
 // true iff any characters were read
 func (d *Decoder) readWhitespace() (bool, error) {
-	isSpace := func(b byte) bool {
-		return b == ' ' ||
-			b == '\t' ||
-			b == '\n' ||
-			b == '\f' ||
-			b == '\r' ||
-			b == '\v'
-	}
-
 	var b byte
 	var err error
 	read := false
-	for b, err = d.readByte(); isSpace(b) && err == nil; b, err = d.readByte() {
+	for b, err = d.readByte(); unicode.IsSpace(rune(b)) && err == nil; b, err = d.readByte() {
 		read = true
 	}
 
@@ -240,7 +232,6 @@ func (d *Decoder) readLines() ([][][2]float64, error) {
 		return nil, d.expected("(")
 	}
 
-
 	_, err = d.readWhitespace()
 	if err != nil {
 		return nil, err
@@ -305,7 +296,6 @@ func (d *Decoder) readPolys() ([][][][2]float64, error) {
 	if err != nil {
 		return nil, err
 	}
-
 
 	b, err = d.readByte()
 	if err != nil {
@@ -545,4 +535,3 @@ func NewDecoder(r io.Reader) *Decoder {
 		src: bufio.NewReader(r),
 	}
 }
-

--- a/encoding/wkt/wkt_encode.go
+++ b/encoding/wkt/wkt_encode.go
@@ -10,74 +10,69 @@ import (
 	"github.com/go-spatial/geom/cmp"
 )
 
+// Encoder holds the necessary configurations and state for
+// a WKT Encoder
 type Encoder struct {
 	w io.Writer
 	fbuf []byte
-
-	// Strict causes the encoder to return errors if the geometries have empty
-	// sub geometries where not allowed by the wkt spec. When Strict
-	// false, empty geometries are ignored.
-	//		Point: can be empty
-	//		MultiPoint: can have empty points
-	//		LineString: cannot have empty points
-	//		MultiLineString: can have empty line strings non-empty line strings cannot have empty points
-	//		Polygon: cannot have empty line strings, non-empty line strings cannot have empty points
-	//		MultiPolygon: can have empty linestrings, polygons cannot have empty linestrings, line strings cannot have empty points
-	//		Collection: can have empty geometries
-	Strict bool
-
-	// The precision that is passed into strconv.FormatFloat
-	// https://golang.org/pkg/strconv/#FormatFloat
-	Precision *int
-
-	// The format flag that is passed into strconv.FormatFloat. If
-	// performance is an issue then, the 'E' or 'e' flag is recommended.
-	// https://golang.org/pkg/strconv/#FormatFloat
-	Fmt byte
+	strict bool
+	precision int
+	fmt byte
 }
 
-var (
-	DefaultEncoderStrict = true
-	DefaultEncoderPrecision = 5
-	DefaultEncoderFmt = byte('g')
-)
+// NewEncoder creates a new encoder that writes to w using the
+// defaults of strict = false, precision = 5, and fmt = 'g'.
+func NewDefaultEncoder(w io.Writer) Encoder {
+	return NewEncoder(w, false, 5, 'g')
+}
 
-func NewEncoder(w io.Writer) *Encoder {
+// NewEncoder creates a new encoder that writes to w
+//
+// strict causes the encoder to return errors if the geometries have empty
+// sub geometries where not allowed by the wkt spec. When Strict
+// false, empty geometries are ignored.
+//		Point: can be empty
+//		MultiPoint: can have empty points
+//		LineString: cannot have empty points
+//		MultiLineString: can have empty line strings non-empty line strings cannot have empty points
+//		Polygon: cannot have empty line strings, non-empty line strings cannot have empty points
+//		MultiPolygon: can have empty polygons, polygons cannot have empty linestrings, line strings cannot have empty points
+//		Collection: can have empty geometries
+//
+// The precision and fmt are passed into strconv.FormatFloat
+// https://golang.org/pkg/strconv/#FormatFloat
+func NewEncoder(w io.Writer, strict bool, precision int, fmt byte) Encoder {
 	// our float would be one of
 	// ddd.ddd with Precision+1 number of d's => Precision + 1 + 1
 	// d.ddde+xx with Precision+1 number of d's => Precision + 1 + 5
-	prec := DefaultEncoderPrecision
-	return &Encoder{
+	return Encoder{
 		w: w,
-		fbuf: make([]byte, 0, prec + 6),
-		Strict: DefaultEncoderStrict,
-		Precision: &prec,
-		Fmt: DefaultEncoderFmt,
+		fbuf: make([]byte, 0, precision + 6),
+		strict: strict,
+		precision: precision,
+		fmt: fmt,
 	}
 }
 
-func (enc *Encoder) byte(b byte) error {
+func (enc Encoder) byte(b byte) error {
 	buf := append(enc.fbuf[:0], b)
 	_, err := enc.w.Write(buf)
 	return err
 }
 
-func (enc *Encoder) string(s string) error {
+func (enc Encoder) string(s string) error {
 	_, err := enc.w.Write([]byte(s))
 	return err
 }
 
 
-func (enc *Encoder) formatFloat(f float64) error {
-	buf := strconv.AppendFloat(enc.fbuf[:0], f, enc.Fmt, *enc.Precision, 64)
+func (enc Encoder) formatFloat(f float64) error {
+	buf := strconv.AppendFloat(enc.fbuf[:0], f, enc.fmt, enc.precision, 64)
 	_, err := enc.w.Write(buf)
 	return err
 }
 
-// var EmptyPoint = [2]float64{math.NaN(), math.NaN()}
-
-
-func (enc *Encoder) encodePair(pt [2]float64) error {
+func (enc Encoder) encodePair(pt [2]float64) error {
 	// should onlt be called for multipoints
 	if cmp.IsEmptyPoint(pt) {
 		return enc.string("EMPTY")
@@ -96,7 +91,7 @@ func (enc *Encoder) encodePair(pt [2]float64) error {
 	return enc.formatFloat(pt[1])
 }
 
-func (enc *Encoder) encodePoint(pt [2]float64) error {
+func (enc Encoder) encodePoint(pt [2]float64) error {
 	// empty point
 	if cmp.IsEmptyPoint(pt) {
 		err := enc.string("EMPTY")
@@ -147,7 +142,7 @@ func lastNonEmptyIdxPolys(polys [][][][2]float64) (last int) {
 }
 
 
-func (enc *Encoder) encodePoints(mp [][2]float64, last int, gType byte) (err error) {
+func (enc Encoder) encodePoints(mp [][2]float64, last int, gType byte) (err error) {
 
 	// the last encode point
 	var firstEnc *[2]float64
@@ -163,7 +158,7 @@ func (enc *Encoder) encodePoints(mp [][2]float64, last int, gType byte) (err err
 		}
 
 		if cmp.IsEmptyPoint(v) {
-			if enc.Strict {
+			if enc.strict {
 				switch gType {
 				case mpType:
 					// multipoints can have empty points
@@ -252,10 +247,10 @@ const (
 	mPolyType
 )
 
-func (enc *Encoder) encodeLines(lines [][][2]float64, last int, gType byte) error {
+func (enc Encoder) encodeLines(lines [][][2]float64, last int, gType byte) error {
 	if gType != mlType {
 		idx := lastNonEmptyIdxLines(lines)
-		if idx != last && enc.Strict {
+		if idx != last && enc.strict {
 			switch gType {
 			case polyType:
 				return errors.New("cannot have empty linear ring in strict POLYGON")
@@ -284,7 +279,7 @@ func (enc *Encoder) encodeLines(lines [][][2]float64, last int, gType byte) erro
 	for _, v := range lines[:last] {
 		// polygons and multipolygons cannot have empty linestrings
 		if lastNonEmptyIdxPoints(v) == -1 {
-			if enc.Strict {
+			if enc.strict {
 				switch gType {
 				case polyType:
 					return errors.New("cannot have empty linear ring in strict POLYGON")
@@ -325,7 +320,7 @@ func (enc *Encoder) encodeLines(lines [][][2]float64, last int, gType byte) erro
 	return enc.byte(')')
 }
 
-func (enc *Encoder) encodePolys(polys [][][][2]float64, last int) error {
+func (enc Encoder) encodePolys(polys [][][][2]float64, last int) error {
 	if last == -1 {
 		return enc.string("EMPTY")
 	}
@@ -359,117 +354,131 @@ func (enc *Encoder) encodePolys(polys [][][][2]float64, last int) error {
 	return enc.byte(')')
 }
 
-func (enc *Encoder) encode(geo geom.Geometry, isCollectionItem bool) error {
+func (enc Encoder) encode(geo geom.Geometry) error {
 
 	switch g := geo.(type) {
-	case [2]float64:
+	case geom.Point:
 		err := enc.string("POINT ")
 		if err != nil {
 			return err
-		}
-		return enc.encodePoint(g)
-
-	case geom.Pointer:
-		if enc.Strict && isCollectionItem && (cmp.IsNil(g) || cmp.IsEmptyPoint(g.XY())) {
-			return nil
-		}
-
-		err := enc.string("POINT ")
-		if err != nil {
-			return err
-		}
-
-		if cmp.IsNil(g) {
-			return enc.string("EMPTY")
 		}
 
 		return enc.encodePoint(g.XY())
 
-	case geom.MultiPointer:
-		var mp [][2]float64
-
-		if !cmp.IsNil(g) {
-			mp = g.Points()
+	case *geom.Point:
+		err := enc.string("POINT ")
+		if err != nil {
+			return err
 		}
 
+		if g == nil {
+			return enc.string("EMPTY")
+		}
+
+		return enc.encode(g.XY())
+
+	case geom.MultiPoint:
 		err := enc.string("MULTIPOINT ")
 		if err != nil {
 			return err
 		}
 
-		err = enc.encodePoints(mp, len(mp) - 1, mpType)
-		return err
+		return enc.encodePoints(g.Points(), len(g) - 1, mpType)
 
-	case geom.LineStringer:
-		var mp [][2]float64
-
-		if !cmp.IsNil(g) {
-			mp = g.Verticies()
+	case *geom.MultiPoint:
+		err := enc.string("MULTIPOINT ")
+		if err != nil {
+			return err
 		}
 
+		if g == nil {
+			return enc.string("EMPTY")
+		}
+
+		return enc.encodePoints(g.Points(), len(*g) - 1, mpType)
+
+	case geom.LineString:
 		err := enc.string("LINESTRING ")
 		if err != nil {
 			return err
 		}
 
-		err = enc.encodePoints(mp, len(mp) - 1, lsType)
+		return enc.encodePoints(g, len(g) - 1, lsType)
+
+	case *geom.LineString:
+		err := enc.string("LINESTRING ")
 		if err != nil {
 			return err
 		}
 
-		return nil
-
-	case geom.MultiLineStringer:
-		var lines [][][2]float64
-
-		if !cmp.IsNil(g) {
-			lines = g.LineStrings()
+		if g == nil {
+			return enc.string("EMPTY")
 		}
 
+		return enc.encodePoints(g.Verticies(), len(*g) - 1, lsType)
 
+	case geom.MultiLineString:
 		err := enc.string("MULTILINESTRING ")
 		if err != nil {
 			return err
 		}
 
-		return enc.encodeLines(lines, len(lines) - 1, mlType)
+		return enc.encodeLines(g.LineStrings(), len(g) - 1, mlType)
 
-	case geom.Polygoner:
-		var lines [][][2]float64
-
-		if !cmp.IsNil(g) {
-			lines = g.LinearRings()
+	case *geom.MultiLineString:
+		err := enc.string("MULTILINESTRING ")
+		if err != nil {
+			return err
 		}
 
+		if g == nil {
+			return enc.string("EMPTY")
+		}
+
+		return enc.encodeLines(g.LineStrings(), len(*g) - 1, mlType)
+
+	case geom.Polygon:
 		err := enc.string("POLYGON ")
 		if err != nil {
 			return err
 		}
 
-		return enc.encodeLines(lines, len(lines) - 1, polyType)
+		return enc.encodeLines(g.LinearRings(), len(g) - 1, polyType)
 
-	case geom.MultiPolygoner:
-		var polys [][][][2]float64
-
-		if !cmp.IsNil(g) {
-			polys = g.Polygons()
+	case *geom.Polygon:
+		err := enc.string("POLYGON ")
+		if err != nil {
+			return err
 		}
 
+		if g == nil {
+			return enc.string("EMPTY")
+		}
+
+		return enc.encodeLines(g.LinearRings(), len(*g) - 1, polyType)
+
+	case geom.MultiPolygon:
 		err := enc.string("MULTIPOLYGON ")
 		if err != nil {
 			return err
 		}
 
-		return enc.encodePolys(polys, len(polys) - 1)
+		return enc.encodePolys(g, len(g) - 1)
 
-	case geom.Collectioner:
-		var geoms []geom.Geometry
-
-		if !cmp.IsNil(g) {
-			geoms = g.Geometries()
+	case *geom.MultiPolygon:
+		err := enc.string("MULTIPOLYGON ")
+		if err != nil {
+			return err
 		}
 
-		if len(geoms) == 0 {
+		if g == nil {
+			return enc.string("EMPTY")
+		}
+
+		return enc.encodePolys(g.Polygons(), len(*g) - 1)
+
+	case geom.Collection:
+		if len(g) == 0 {
 			return enc.string("GEOMETRYCOLLECTION EMPTY")
 		}
 
@@ -483,10 +492,10 @@ func (enc *Encoder) encode(geo geom.Geometry, isCollectionItem bool) error {
 			return err
 		}
 
-		last := len(geoms) - 1
+		last := len(g) - 1
 
-		for _, v := range geoms[:last] {
-			err = enc.encode(v, true)
+		for _, v := range g[:last] {
+			err = enc.encode(v)
 			if err != nil {
 				return err
 			}
@@ -497,23 +506,36 @@ func (enc *Encoder) encode(geo geom.Geometry, isCollectionItem bool) error {
 			}
 		}
 
-		err = enc.encode(geoms[last], true)
+		err = enc.encode(g[last])
 		if err != nil {
 			return err
 		}
 
 		return enc.byte(')')
 
+	case *geom.Collection:
+		if g == nil {
+			return enc.string("GEOMETRYCOLLECTION EMPTY")
+		}
+
+		return enc.encode(*g)
+
 	// non basic types
 
-	case geom.Line:
-		return enc.encode(geom.LineString(g[:]), false)
-
-	case [2][2]float64:
-		return enc.encode(geom.LineString(g[:]), false)
+	case [2]float64:
+		return enc.encode(geom.Point(g))
 
 	case [][2]float64:
-		return enc.encode(geom.LineString(g), false)
+		return enc.encode(geom.MultiPoint(g))
+
+	case [][][2]float64:
+		return enc.encode(geom.MultiLineString(g))
+
+	case geom.Line:
+		return enc.encode(geom.LineString(g[:]))
+
+	case [2][2]float64:
+		return enc.encode(geom.LineString(g[:]))
 
 	case []geom.Line:
 		lines := make(geom.MultiLineString, len(g))
@@ -521,7 +543,7 @@ func (enc *Encoder) encode(geo geom.Geometry, isCollectionItem bool) error {
 			lines[i] = [][2]float64(v[:])
 		}
 
-		return enc.encode(lines, false)
+		return enc.encode(lines)
 
 	case []geom.Point:
 		points := make(geom.MultiPoint, len(g))
@@ -529,40 +551,28 @@ func (enc *Encoder) encode(geo geom.Geometry, isCollectionItem bool) error {
 			points[i] = v
 		}
 
-		return enc.encode(points, false)
+		return enc.encode(points)
 
 	case geom.Triangle:
-		return enc.encode(geom.Polygon{g[:]}, false)
+		return enc.encode(geom.Polygon{g[:]})
 
 	case geom.Extent:
-		return enc.encode(g.AsPolygon(), false)
+		return enc.encode(g.AsPolygon())
 
 	case *geom.Extent:
 		if g != nil {
-			return enc.encode(g.AsPolygon(), false)
+			return enc.encode(g.AsPolygon())
 		}
 
-		return enc.encode(geom.Polygon{}, false)
+		return enc.encode(geom.Polygon{})
 
 	default:
 		return fmt.Errorf("unknown geometry: %T", geo)
 	}
 }
 
-func (enc *Encoder) Encode(geo geom.Geometry) error {
-
-	if enc.Precision == nil {
-		prec := DefaultEncoderPrecision
-		enc.Precision = &prec
-	}
-
-	if enc.fbuf == nil {
-		enc.fbuf = make([]byte, 0, *enc.Precision + 6)
-	}
-
-	if enc.Fmt == 0 {
-		enc.Fmt = DefaultEncoderFmt
-	}
-
-	return enc.encode(geo, false)
+// Encode traverses the geometry and writes its WKT representation to the
+// encoder's io.Writer and returns the first error it may have gotten.
+func (enc Encoder) Encode(geo geom.Geometry) error {
+	return enc.encode(geo)
 }

--- a/encoding/wkt/wkt_test.go
+++ b/encoding/wkt/wkt_test.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"testing"
 
-	"github.com/arolek/p"
 	"github.com/go-spatial/geom"
 	gtesting "github.com/go-spatial/geom/testing"
 )
@@ -23,10 +22,7 @@ func TestEncode(t *testing.T) {
 			t.Parallel()
 
 			buf := &bytes.Buffer{}
-			enc := NewEncoder(buf)
-			enc.Strict = tc.Strict
-			enc.Precision = p.Int(6)
-			enc.Fmt = 'g'
+			enc := NewEncoder(buf, tc.Strict, 6, 'g')
 
 			gerr := enc.Encode(tc.Geom)
 			grep := buf.String()

--- a/encoding/wkt/wkt_tile_test.go
+++ b/encoding/wkt/wkt_tile_test.go
@@ -22,7 +22,7 @@ func BenchmarkEncodeTilePrealloc(b *testing.B) {
 		// the encoded wkt is ~32MB
 		buf := bytes.NewBuffer(make([]byte, 0, (1<<20)*32))
 		enc := NewEncoder(buf)
-		enc.Encode(gtesting.Tiles()[0], true)
+		enc.Encode(gtesting.Tiles()[0])
 	}
 }
 
@@ -30,6 +30,6 @@ func BenchmarkEncodeTileNoprealloc(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		buf := bytes.NewBuffer(make([]byte, 0, 0))
 		enc := NewEncoder(buf)
-		enc.Encode(gtesting.Tiles()[0], true)
+		enc.Encode(gtesting.Tiles()[0])
 	}
 }

--- a/encoding/wkt/wkt_tile_test.go
+++ b/encoding/wkt/wkt_tile_test.go
@@ -21,7 +21,7 @@ func BenchmarkEncodeTilePrealloc(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		// the encoded wkt is ~32MB
 		buf := bytes.NewBuffer(make([]byte, 0, (1<<20)*32))
-		enc := NewEncoder(buf)
+		enc := NewDefaultEncoder(buf)
 		enc.Encode(gtesting.Tiles()[0])
 	}
 }
@@ -29,7 +29,7 @@ func BenchmarkEncodeTilePrealloc(b *testing.B) {
 func BenchmarkEncodeTileNoprealloc(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		buf := bytes.NewBuffer(make([]byte, 0, 0))
-		enc := NewEncoder(buf)
+		enc := NewDefaultEncoder(buf)
 		enc.Encode(gtesting.Tiles()[0])
 	}
 }


### PR DESCRIPTION
This would close #81, refer to that issue for more context.

* exposed various encoder options
    * `Precision` for `strconv.FormatFloat`
    * `Fmt` for `strconv.FormatFloat`, this wasn't talked about but I think it's be helpful 
    * `Strict` see next bullet
* empy points never printed by decoder
    * new strict decoding for stricter error checking
* moved some utility funcitons out of wkt into cmp
* imporoved performance and stability of encoder in removing whitespace
    * I noticed this while running benchmarks on the decoder because it is called by `init` to decode a tile

There isn't much of a performance difference, most of the cpu time is spent in `encodeFloat` so
slight logic changes don't mean much.

**todo:** add tests to the `cmp` functions