### PR TITLE
Fix usage of the word "verticies" to "vertices"

### DIFF
--- a/bbox.go
+++ b/bbox.go
@@ -34,9 +34,6 @@ func (e *Extent) Vertices() [][2]float64 {
 	}
 }
 
-// Verticies is the misspelled version of Vertices to match the interface
-func (e *Extent) Verticies() [][2]float64 { return e.Vertices() }
-
 // ClockwiseFunc returns weather the set of points should be considered clockwise or counterclockwise. The last point is not the same as the first point, and the function should connect these points as needed.
 type ClockwiseFunc func(...[2]float64) bool
 

--- a/cmp/compare.go
+++ b/cmp/compare.go
@@ -223,7 +223,7 @@ func (cmp Compare) LineStringerEqual(geo1, geo2 geom.LineStringer) bool {
 	if geo1Nil, geo2Nil := geo1 == NilLineString, geo2 == NilLineString; geo1Nil || geo2Nil {
 		return geo1Nil && geo2Nil
 	}
-	return cmp.LineStringEqual(geo1.Verticies(), geo2.Verticies())
+	return cmp.LineStringEqual(geo1.Vertices(), geo2.Vertices())
 }
 
 // MultiLineStringerEqual will check to see if the 2 MultiLineStrings pass to it

--- a/cmp/empty.go
+++ b/cmp/empty.go
@@ -69,13 +69,13 @@ func IsEmptyGeo(geo geom.Geometry) (isEmpty bool, err error) {
 		return IsEmptyPoints(g.Points()), nil
 
 	case geom.LineString:
-		return IsEmptyPoints(g.Verticies()), nil
+		return IsEmptyPoints(g.Vertices()), nil
 
 	case *geom.LineString:
 		if g == nil {
 			return true, nil
 		}
-		return IsEmptyPoints(g.Verticies()), nil
+		return IsEmptyPoints(g.Vertices()), nil
 
 	case geom.MultiLineString:
 		return IsEmptyLines(g.LineStrings()), nil

--- a/encoding/geojson/geojson.go
+++ b/encoding/geojson/geojson.go
@@ -51,7 +51,7 @@ func (geo Geometry) MarshalJSON() ([]byte, error) {
 	case geom.LineStringer:
 		return json.Marshal(coordinates{
 			Type:   LineStringType,
-			Coords: g.Verticies(),
+			Coords: g.Vertices(),
 		})
 
 	case geom.MultiLineStringer:

--- a/encoding/mvt/feature.go
+++ b/encoding/mvt/feature.go
@@ -301,7 +301,7 @@ func encodeGeometry(ctx context.Context, geometry geom.Geometry) (g []uint32, vt
 		return g, vectorTile.Tile_POINT, nil
 
 	case geom.LineString:
-		points := t.Verticies()
+		points := t.Vertices()
 		g = append(g, c.MoveTo(points[0])...)
 		g = append(g, c.LineTo(points[1:]...)...)
 		return g, vectorTile.Tile_LINESTRING, nil
@@ -309,7 +309,7 @@ func encodeGeometry(ctx context.Context, geometry geom.Geometry) (g []uint32, vt
 	case geom.MultiLineString:
 		lines := t.LineStrings()
 		for _, l := range lines {
-			points := geom.LineString(l).Verticies()
+			points := geom.LineString(l).Vertices()
 			g = append(g, c.MoveTo(points[0])...)
 			g = append(g, c.LineTo(points[1:]...)...)
 		}

--- a/encoding/wkb/internal/encode/encode.go
+++ b/encoding/wkb/internal/encode/encode.go
@@ -134,7 +134,7 @@ func (en *Encoder) Geometry(g geom.Geometry) {
 	case geom.MultiPointer:
 		en.MultiPoint(geo.Points())
 	case geom.LineStringer:
-		en.LineString(geo.Verticies())
+		en.LineString(geo.Vertices())
 	case geom.MultiLineStringer:
 		en.MultiLineString(geo.LineStrings())
 	case geom.Polygoner:

--- a/encoding/wkt/wkt_encode.go
+++ b/encoding/wkt/wkt_encode.go
@@ -412,7 +412,7 @@ func (enc Encoder) encode(geo geom.Geometry) error {
 			return enc.string("EMPTY")
 		}
 
-		return enc.encodePoints(g.Verticies(), len(*g)-1, lsType)
+		return enc.encodePoints(g.Vertices(), len(*g)-1, lsType)
 
 	case geom.MultiLineString:
 		err := enc.string("MULTILINESTRING ")

--- a/geom.go
+++ b/geom.go
@@ -25,7 +25,7 @@ type MultiPointer interface {
 // LineStringer is a line of two or more points.
 type LineStringer interface {
 	Geometry
-	Verticies() [][2]float64
+	Vertices() [][2]float64
 }
 
 // MultiLineStringer is a geometry with multiple LineStrings.
@@ -79,7 +79,7 @@ func getCoordinates(g Geometry, pts *[]Point) error {
 
 	case LineStringer:
 
-		mpts := gg.Verticies()
+		mpts := gg.Vertices()
 		for i := range mpts {
 			*pts = append(*pts, Point(mpts[i]))
 		}
@@ -152,7 +152,7 @@ func getExtent(g Geometry, e *Extent) error {
 		return nil
 
 	case LineStringer:
-		e.AddPoints(gg.Verticies()...)
+		e.AddPoints(gg.Vertices()...)
 		return nil
 
 	case MultiLineStringer:
@@ -213,7 +213,7 @@ func extractLines(g Geometry, lines *[]Line) error {
 
 	case LineStringer:
 
-		v := gg.Verticies()
+		v := gg.Vertices()
 		for i := 0; i < len(v)-1; i++ {
 			*lines = append(*lines, Line{v[i], v[i+1]})
 		}
@@ -235,7 +235,7 @@ func extractLines(g Geometry, lines *[]Line) error {
 			if err := extractLines(lr, lines); err != nil {
 				return err
 			}
-			v := lr.Verticies()
+			v := lr.Vertices()
 			if len(v) > 2 && lr.IsRing() == false {
 				// create a connection from last -> first if it doesn't exist
 				*lines = append(*lines, Line{v[len(v)-1], v[0]})
@@ -295,7 +295,7 @@ func IsEmpty(geo Geometry) bool {
 	case LineString:
 		return len(g) == 0
 	case LineStringer:
-		return len(g.Verticies()) == 0
+		return len(g.Vertices()) == 0
 	case Polygon:
 		return len(g) == 0
 	case Polygoner:

--- a/line.go
+++ b/line.go
@@ -25,7 +25,7 @@ func (l Line) Point1() *Point { return (*Point)(&l[0]) }
 // Point2 returns a new copy of the second point in the line.
 func (l Line) Point2() *Point { return (*Point)(&l[1]) }
 
-func (l Line) Verticies() [][2]float64 { return l[:] }
+func (l Line) Vertices() [][2]float64 { return l[:] }
 
 // ContainsPoint checks to see if the given pont lines on the linesegment. (Incliding the end points.)
 func (l Line) ContainsPoint(pt [2]float64) bool {

--- a/line_string.go
+++ b/line_string.go
@@ -29,11 +29,11 @@ func (ls LineString) IsRing() bool {
 	return false
 }
 
-// Verticies returns a slice of XY values
-func (ls LineString) Verticies() [][2]float64 { return ls }
+// Vertices returns a slice of XY values
+func (ls LineString) Vertices() [][2]float64 { return ls }
 
-// SetVerticies modifies the array of 2D coordinates
-func (ls *LineString) SetVerticies(input [][2]float64) (err error) {
+// SetVertices modifies the array of 2D coordinates
+func (ls *LineString) SetVertices(input [][2]float64) (err error) {
 	if ls == nil {
 		return ErrNilLineString
 	}

--- a/line_string_test.go
+++ b/line_string_test.go
@@ -16,7 +16,7 @@ func TestLineStringSetter(t *testing.T) {
 		err      error
 	}
 	fn := func(t *testing.T, tc tcase) {
-		err := tc.setter.SetVerticies(tc.points)
+		err := tc.setter.SetVertices(tc.points)
 		if tc.err == nil && err != nil {
 			t.Errorf("error, expected nil got %v", err)
 			return
@@ -31,9 +31,9 @@ func TestLineStringSetter(t *testing.T) {
 		if !reflect.DeepEqual(tc.expected, tc.setter) {
 			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
 		}
-		ls := tc.setter.Verticies()
+		ls := tc.setter.Vertices()
 		if !reflect.DeepEqual(tc.points, ls) {
-			t.Errorf("Verticies, expected %v got %v", tc.points, ls)
+			t.Errorf("Vertices, expected %v got %v", tc.points, ls)
 		}
 	}
 	tests := []tcase{

--- a/planar/clip/linestring.go
+++ b/planar/clip/linestring.go
@@ -39,7 +39,7 @@ func uniqueSegmentIntersectPoints(clipbox *geom.Extent, ln geom.Line) [][2]float
 
 // LineString will clip the give linestring to the the given clipbox, breaking it up into multiple linestring as needed.
 func LineStringer(ctx context.Context, linestringer geom.LineStringer, clipbox *geom.Extent) (mls geom.MultiLineString, err error) {
-	return lineString(ctx, linestringer.Verticies(), clipbox)
+	return lineString(ctx, linestringer.Vertices(), clipbox)
 }
 
 func lineString(ctx context.Context, ls [][2]float64, clipbox *geom.Extent) (mls geom.MultiLineString, err error) {

--- a/planar/simplify.go
+++ b/planar/simplify.go
@@ -75,7 +75,7 @@ func Simplify(ctx context.Context, simplifer Simplifer, geometry geom.Geometry) 
 
 	case geom.LineStringer:
 
-		ls, err := simplifer.Simplify(ctx, gg.Verticies(), false)
+		ls, err := simplifer.Simplify(ctx, gg.Vertices(), false)
 		if err != nil {
 			return nil, err
 		}

--- a/set_geom.go
+++ b/set_geom.go
@@ -19,7 +19,7 @@ type MultiPointSetter interface {
 // LineStringSetter is a mutable LineStringer.
 type LineStringSetter interface {
 	LineStringer
-	SetVerticies([][2]float64) error
+	SetVertices([][2]float64) error
 }
 
 // MultiLineStringSetter is a mutable MultiLineStringer.


### PR DESCRIPTION
To apply this change (to any code base), one line of bash can be used:

```
sed  -e 's/\([Vv]\)erticies/\1ertices/g' -i '' $(grep -e '[Vv]erticies' -r . -l --exclude='./.git/*')
```

closes #44 