### PR TITLE
[mvt] fix encoder tests and added decoder

### DIFF
--- a/encoding/mvt/decode.go
+++ b/encoding/mvt/decode.go
@@ -1,0 +1,305 @@
+package mvt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/arolek/p"
+	"github.com/go-spatial/geom"
+	vectorTile "github.com/go-spatial/geom/encoding/mvt/vector_tile"
+	"github.com/go-spatial/geom/winding"
+	"github.com/golang/protobuf/proto"
+)
+
+// TileGeomCollection returns all geometries in a tile
+// as a collection
+func TileGeomCollection(tile *Tile) geom.Collection {
+	ret := geom.Collection{}
+	for _, v := range tile.layers {
+		for _, vv := range v.features {
+			ret = append(ret, vv.Geometry)
+		}
+	}
+
+	return ret
+}
+
+// Decode reads all the data from r and decodes the MVT tile into a Tile
+// TODO(ear7h): handle tile tags
+func Decode(r io.Reader) (*Tile, error) {
+	byt, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return DecodeByte(byt)
+}
+
+// DecodeByte decodes the MVT encoded bytes into a Tile.
+// TODO(ear7h): handle tile tags
+func DecodeByte(b []byte) (*Tile, error) {
+	vtile := new(vectorTile.Tile)
+
+	err := proto.Unmarshal(b, vtile)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := new(Tile)
+	ret.layers = make([]Layer, len(vtile.Layers))
+
+	for i, v := range vtile.Layers {
+		err = decodeLayer(v, &ret.layers[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ret, nil
+}
+
+func decodeLayer(pb *vectorTile.Tile_Layer, dst *Layer) error {
+	dst.Name = *pb.Name
+	dst.extent = p.Int(int(*pb.Extent))
+
+	dst.features = make([]Feature, len(pb.Features))
+
+	for i, v := range pb.Features {
+		err := decodeFeature(v, &dst.features[i])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func decodeFeature(pb *vectorTile.Tile_Feature, dst *Feature) error {
+	dst.ID = pb.Id
+	// TODO tag support
+	var err error
+	dst.Geometry, err = DecodeGeometry(*pb.Type, pb.Geometry)
+	return err
+}
+
+func DecodeGeometry(gtype vectorTile.Tile_GeomType, b []uint32) (geom.Geometry, error) {
+
+	switch gtype {
+	case vectorTile.Tile_LINESTRING:
+		return decodeLineString(b)
+	case vectorTile.Tile_POINT:
+		return decodePoint(b)
+	case vectorTile.Tile_POLYGON:
+		return decodePoly(b)
+	default:
+		panic("unreachable")
+	}
+}
+
+func decodePoint(buf []uint32) (geom.Geometry, error) {
+	ret := [][2]float64{}
+	curs := decodeCursor{}
+
+	if len(buf) > 0 {
+		cmd := Command(buf[0])
+		buf = buf[1:]
+
+		if len(buf) < cmd.Count()*2 {
+			return nil, fmt.Errorf("not enough integers (%v) for %s", len(buf), cmd)
+		}
+
+		switch cmd.ID() {
+		case cmdMoveTo:
+			ret = curs.decodeNPoints(cmd.Count(), buf, false)
+			buf = buf[cmd.Count()*2:]
+
+		default:
+			return nil, fmt.Errorf("invalid command for POINT, %s", cmd)
+		}
+	}
+
+	if len(buf) != 0 {
+		fmt.Println(buf)
+		return ret, ErrExtraData
+	}
+
+	switch len(ret) {
+	case 0:
+		return nil, nil
+	case 1:
+		return geom.Point(ret[0]), nil
+	default:
+		return geom.MultiPoint(ret), nil
+	}
+}
+
+var ErrExtraData = errors.New("mvt: invalid extra data")
+
+func decodeLineString(buf []uint32) (geom.Geometry, error) {
+	ret := [][][2]float64{}
+	curs := decodeCursor{}
+	var lastCmd Command
+	var cmd Command
+
+	for ; len(buf) > 0; lastCmd = cmd {
+		cmd = Command(buf[0])
+		buf = buf[1:]
+
+		if len(buf) < cmd.Count()*2 {
+			return nil, fmt.Errorf("not enough integers (%v) for %s", len(buf), cmd)
+		}
+
+		switch cmd.ID() {
+		case cmdMoveTo:
+			if lastCmd != 0 && lastCmd.ID() != cmdLineTo {
+				return nil, fmt.Errorf("%v cannot follow %v for LINESTRING", cmd, lastCmd)
+			}
+
+			if cmd.Count() != 1 {
+				// return error
+			}
+
+			curs.decodePoint(buf[0], buf[1])
+			buf = buf[2:]
+
+		case cmdLineTo:
+			if lastCmd.ID() != cmdMoveTo {
+				return nil, fmt.Errorf("%v cannot follow %v for LINESTRING", cmd, lastCmd)
+			}
+
+			if cmd.Count() <= 0 {
+				return nil, fmt.Errorf("%v must have count > 0 for LINESTRING", cmd)
+			}
+
+			ln := curs.decodeNPoints(cmd.Count(), buf, true)
+			buf = buf[cmd.Count()*2:]
+			ret = append(ret, ln)
+
+		default:
+			return nil, fmt.Errorf("invalid command for LINESTRING, %s", cmd)
+		}
+	}
+
+	if len(buf) != 0 {
+		return ret, ErrExtraData
+	}
+
+	switch len(ret) {
+	case 0:
+		panic("unreachable")
+	case 1:
+		return geom.LineString(ret[0]), nil
+	default:
+		return geom.MultiLineString(ret), nil
+	}
+}
+
+func decodePoly(buf []uint32) (geom.Geometry, error) {
+	ret := [][][][2]float64{}
+	curs := decodeCursor{}
+	var lastCmd Command
+	var cmd Command
+
+	for ; len(buf) > 0; lastCmd = cmd {
+		cmd = Command(buf[0])
+		buf = buf[1:]
+
+		if cmd.ID() != cmdClosePath && len(buf) < cmd.Count()*2 {
+			return nil, fmt.Errorf("not enough integers (%v) for %s", len(buf), cmd)
+		}
+
+		switch cmd.ID() {
+		case cmdMoveTo:
+			if lastCmd != 0 && lastCmd.ID() != cmdClosePath {
+				return nil, fmt.Errorf("%v cannot follow %v for POLYGON", cmd, lastCmd)
+			}
+
+			if cmd.Count() != 1 {
+				// cannot be 1
+			}
+
+			curs.decodePoint(buf[0], buf[1])
+			buf = buf[2:]
+
+		case cmdLineTo:
+			if lastCmd.ID() != cmdMoveTo {
+				return nil, fmt.Errorf("%v cannot follow %v for POLYGON", cmd, lastCmd)
+			}
+
+			if cmd.Count() <= 1 {
+				return nil, fmt.Errorf("%v must have count > 1 for POLYGON", cmd)
+			}
+
+			ln := curs.decodeNPoints(cmd.Count(), buf, true)
+			buf = buf[cmd.Count()*2:]
+
+			if (winding.Order{YPositiveDown: true}).OfPoints(ln...).IsClockwise() {
+				ret = append(ret, nil)
+			} else if len(ret) == 0 {
+				return nil, fmt.Errorf("first ring of POLYGON must be an exterior ring")
+			}
+
+			polyIdx := len(ret) - 1
+			ret[polyIdx] = append(ret[polyIdx], ln)
+
+		case cmdClosePath:
+			if lastCmd.ID() != cmdLineTo {
+				return nil, fmt.Errorf("%v cannot follow %v for POLYGON", cmd, lastCmd)
+			}
+		}
+	}
+
+	if len(buf) != 0 {
+		return ret, ErrExtraData
+	}
+
+	switch len(ret) {
+	case 0:
+		panic("unreachable")
+	case 1:
+		return geom.Polygon(ret[0]), nil
+	default:
+		return geom.MultiPolygon(ret), nil
+	}
+}
+
+type decodeCursor struct {
+	x, y float64
+}
+
+// n and len(pts) should be error checked before this function
+// this is for more informative context on errors
+func (c *decodeCursor) decodeNPoints(n int, pts []uint32, encHere bool) [][2]float64 {
+	nd := 0
+
+	if encHere {
+		nd = 1
+	}
+
+	ret := make([][2]float64, n+nd)
+
+	if encHere {
+		ret[0] = [2]float64{c.x, c.y}
+	}
+
+	for i := 0; i < n; i++ {
+		ret[i+nd] = c.decodePoint(pts[i*2], pts[i*2+1])
+	}
+
+	return ret
+}
+
+// decodes the zig zag encoded uint32's, moves the cursor
+func (c *decodeCursor) decodePoint(x, y uint32) [2]float64 {
+	c.x += float64(decodeZigZag(x))
+	c.y += float64(decodeZigZag(y))
+	return [2]float64{c.x, c.y}
+}
+
+// decodes the zig zag encoded int32
+func decodeZigZag(i uint32) int32 {
+	return int32((i >> 1) ^ (-(i & 1)))
+}

--- a/encoding/mvt/decode_internal_test.go
+++ b/encoding/mvt/decode_internal_test.go
@@ -1,0 +1,83 @@
+package mvt
+
+import (
+	"testing"
+
+	"github.com/go-spatial/geom"
+	"github.com/go-spatial/geom/cmp"
+	vectorTile "github.com/go-spatial/geom/encoding/mvt/vector_tile"
+)
+
+func TestDecode(t *testing.T) {
+	type tcase struct {
+		typ vectorTile.Tile_GeomType
+		buf []uint32
+		geo geom.Geometry
+		err error
+	}
+
+	fn := func(tc tcase) func(t *testing.T) {
+		return func(t *testing.T) {
+			geo, err := DecodeGeometry(tc.typ, tc.buf)
+			if err != nil {
+				if tc.err == nil {
+					t.Errorf("unexpected error %v", err)
+				} else if tc.err.Error() == err.Error() {
+					t.Errorf("unexpeced error %v, expected %v",
+						err, tc.err)
+				}
+				return
+			}
+
+			if !cmp.GeometryEqual(geo, tc.geo) {
+				t.Errorf("incorrect geometry, expected\n\t%v\ngot\n\t%v", tc.geo, geo)
+			}
+		}
+	}
+
+	// TODO(ear7h) error test cases/fuzzing
+	testcases := map[string]tcase {
+		"point": {
+			typ: vectorTile.Tile_POINT,
+			buf: []uint32{9, 50, 34},
+			geo: geom.Point{25, 17},
+		},
+		"multi point": {
+			typ: vectorTile.Tile_POINT,
+			buf: []uint32{17, 10, 14, 3, 9},
+			geo: geom.MultiPoint{{5, 7}, {3, 2}},
+		},
+		"line string": {
+			typ: vectorTile.Tile_LINESTRING,
+			buf: []uint32{9, 4, 4, 18, 0, 16, 16, 0},
+			geo: geom.LineString{{2, 2}, {2, 10}, {10, 10}},
+		},
+		"multi line string": {
+			typ: vectorTile.Tile_LINESTRING,
+			buf: []uint32{9, 4, 4, 18, 0, 16, 16, 0, 9, 17, 17, 10, 4, 8},
+			geo: geom.MultiLineString{{{2, 2}, {2, 10}, {10, 10}}, {{1, 1}, {3, 5}}},
+		},
+		"polygon": {
+			typ: vectorTile.Tile_POLYGON,
+			buf: []uint32{9, 6, 12, 18, 10, 12, 24, 44, 15},
+			geo: geom.Polygon{{{3, 6}, {8, 12}, {20, 34}}},
+		},
+		"multi polygon": {
+			typ: vectorTile.Tile_POLYGON,
+			buf: []uint32{9, 0, 0, 26, 20, 0, 0, 20, 19, 0, 15, 9, 22, 2, 26, 18, 0, 0, 18, 17, 0, 15, 9, 4, 13, 26, 0, 8, 8, 0, 0, 7, 15},
+			geo: geom.MultiPolygon{
+				{ // poly 1
+					{{0, 0}, {10, 0}, {10, 10}, {0, 10}},
+				},
+				{ // poly 2
+					{{11, 11}, {20, 11}, {20, 20}, {11, 20}},
+					{{13, 13}, {13, 17}, {17, 17}, {17, 13}},
+				},
+			},
+		},
+	}
+
+	for k, v := range testcases {
+		t.Run(k, fn(v))
+	}
+}

--- a/encoding/mvt/feature_test.go
+++ b/encoding/mvt/feature_test.go
@@ -30,6 +30,7 @@ func TestEncodePolygon(t *testing.T) {
 				x: tc.x,
 				y: tc.y,
 			}
+
 			g := c.encodePolygon(tc.Polygon)
 			if len(g) != len(tc.g) {
 				t.Errorf("g length, expected %v, got %v", len(tc.g), len(g))
@@ -54,23 +55,36 @@ func TestEncodePolygon(t *testing.T) {
 				}
 				return
 			}
+
+			// pad index
+			iPad := int(math.Log10(float64(len(tc.g)))) + 1
+			// pad expected
+			ePad := 0
+			// pad got
+			gPad := 0
+
 			for i := range tc.g {
-				// calculate the amount of padding needed to format the numbers
-				gl := int(math.Log10(float64(g[i]))) + 1
-				tcl := int(math.Log10(float64(tc.g[i]))) + 1
-				if gl < tcl {
-					gl = tcl
+				v := int(math.Log10(float64(tc.g[i]))) + 1
+				if ePad < v {
+					ePad = v
 				}
+
+				v = int(math.Log10(float64(g[i]))) + 1
+				if gPad < v {
+					gPad = v
+				}
+			}
+
+			for i := range tc.g {
 				if tc.g[i] != g[i] {
-					t.Errorf("value not correct for %d, expected %0*d got %0*d", i, gl, tc.g[i], gl, g[i])
+					t.Errorf("value not correct for %*d, expected %*d got %*d",
+						iPad, i, ePad, tc.g[i], gPad, g[i])
 				}
 			}
 		}
 	}
 
-	tests := map[string]tcase{}
-
-	testForFile := func(file string) {
+	testForFile := func(file string) tcase {
 
 		var sol []uint32
 		filename := filepath.Join("testdata", file)
@@ -90,15 +104,15 @@ func TestEncodePolygon(t *testing.T) {
 			}
 		}
 
-		tests[file] = tcase{
+		return tcase{
 			Polygon: poly,
 			g:       sol,
 		}
 	}
-	for _, file := range []string{"florida_keys"} {
-		testForFile(file)
-	}
-	for name, tc := range tests {
-		t.Run(name, fn(tc))
+
+	tests := []string{"florida_keys"}
+
+	for _, name := range tests {
+		t.Run(name, fn(testForFile(name)))
 	}
 }

--- a/polygon.go
+++ b/polygon.go
@@ -16,7 +16,7 @@ var ErrInvalidPolygon = errors.New("geom: invalid Polygon")
 // Polygon is a geometry consisting of multiple closed LineStrings.
 // There must be only one exterior LineString with a clockwise winding order.
 // There may be one or more interior LineStrings with a counterclockwise winding orders.
-// The last point in the polygon will not match the first point.
+// The last point in the linear ring will not match the first point.
 type Polygon [][][2]float64
 
 // LinearRings returns the coordinates of the linear rings

--- a/testing/dynamic_geoms.go
+++ b/testing/dynamic_geoms.go
@@ -9,7 +9,7 @@ import (
 // BoxPolygon returns a polygon that is a box with side lengths of
 // dim, a clockwise winding order, and points at (0, 0) and (dim, dim).
 func BoxPolygon(dim float64) geom.Polygon {
-	return geom.Polygon{{{0, 0}, {dim, 0}, {dim, dim}, {0, dim}}}
+	return geom.Polygon{{{0, 0}, {0, dim}, {dim, dim}, {dim, 0}}}
 }
 
 func SelfIntBoxLineString(dim float64) geom.LineString {

--- a/testing/dynamic_geoms_test.go
+++ b/testing/dynamic_geoms_test.go
@@ -34,11 +34,11 @@ func TestBoxPolygon(t *testing.T) {
 	tcases := map[string]tcase{
 		"dim 1": {
 			dim: 1.0,
-			res: geom.Polygon{{{0, 0}, {1.0, 0}, {1.0, 1.0}, {0, 1.0}}},
+			res: geom.Polygon{{{0, 0}, {0, 1.0}, {1.0, 1.0}, {1.0, 0}}},
 		},
 		"dim -1": {
 			dim: -1.0,
-			res: geom.Polygon{{{0, 0}, {-1.0, 0}, {-1.0, -1.0}, {0, -1.0}}},
+			res: geom.Polygon{{{0, 0}, {0, -1.0}, {-1.0, -1.0}, {-1.0, 0}}},
 		},
 	}
 

--- a/winding/winding.go
+++ b/winding/winding.go
@@ -162,7 +162,7 @@ func Orientation(yPositiveDown bool, pts ...[2]float64) Winding {
 		adjusted[i] = [2]float64{pts[i][0] - pts[0][0], pts[i][1] - pts[0][1]}
 	}
 
-	return Winding(mul * Orient(pts...))
+	return Winding(mul * Orient(adjusted...))
 }
 
 // Order configures how the orientation of a set of points is determined


### PR DESCRIPTION
* the mvt encoder now uses the YPositiveDown field of winding.Order
* added the mvt decoder

I added the decoder as a rider to this pr, but it can be removed if it should be merged somewhere else.