### PR TITLE
Add extended types for MultiPoint geometries

### DIFF
--- a/geom.go
+++ b/geom.go
@@ -76,6 +76,60 @@ type MultiPointer interface {
 	Points() [][2]float64
 }
 
+// MultiPointZer is a geometry with multiple 3D points.
+type MultiPointZer interface {
+	Geometry
+	Points() [][3]float64
+}
+
+// MultiPointMer is a geometry with multiple 2+1D points.
+type MultiPointMer interface {
+	Geometry
+	Points() [][3]float64
+}
+
+// MultiPointZMer is a geometry with multiple 3+1D points.
+type MultiPointZMer interface {
+	Geometry
+	Points() [][4]float64
+}
+
+// MultiPointSer is a MultiPoint + SRID.
+type MultiPointSer interface {
+	Geometry
+	Points() struct {
+		Srid uint32
+		Mp   MultiPoint
+	}
+}
+
+// MultiPointZSer is a MultiPointZ + SRID.
+type MultiPointZSer interface {
+	Geometry
+	Points() struct {
+		Srid uint32
+		Mpz  MultiPointZ
+	}
+}
+
+// MultiPointMSer is a MultiPointM + SRID.
+type MultiPointMSer interface {
+	Geometry
+	Points() struct {
+		Srid uint32
+		Mpm  MultiPointM
+	}
+}
+
+// MultiPointZMSer is a MultiPointZM + SRID.
+type MultiPointZMSer interface {
+	Geometry
+	Points() struct {
+		Srid uint32
+		Mpzm MultiPointZM
+	}
+}
+
 // LineStringer is a line of two or more points.
 type LineStringer interface {
 	Geometry

--- a/multi_pointm.go
+++ b/multi_pointm.go
@@ -1,0 +1,38 @@
+package geom
+
+import "errors"
+
+// ErrNilMultiPointM is thrown when a MultiPointM is nil but shouldn't be
+var ErrNilMultiPointM = errors.New("geom: nil MultiPointM")
+
+// MultiPointM is a geometry with multiple 2+1D points.
+type MultiPointM [][3]float64
+
+// Points returns the coordinates for the 2+1D points
+func (mpm MultiPointM) Points() [][3]float64 {
+	return mpm
+}
+
+// SetPoints modifies the array of 2+1D coordinates
+func (mpm *MultiPointM) SetPoints(input [][3]float64) (err error) {
+	if mpm == nil {
+		return ErrNilMultiPointM
+	}
+
+	*mpm = append((*mpm)[:0], input...)
+	return
+}
+
+// Get the simple 2D multipoint
+func (mpm MultiPointM) MultiPoint() MultiPoint {
+	var mpv [][2]float64
+	var mp MultiPoint
+
+	points := mpm.Points()
+	for i := 0; i < len(points); i++ {
+		mpv = append(mpv, [2]float64{points[i][0], points[i][1]})
+	}
+
+	mp.SetPoints(mpv)
+	return mp
+}

--- a/multi_pointm_test.go
+++ b/multi_pointm_test.go
@@ -1,0 +1,67 @@
+package geom_test
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/go-spatial/geom"
+)
+
+func TestMultiPointMSetter(t *testing.T) {
+	type tcase struct {
+		points   [][3]float64
+		setter   geom.MultiPointMSetter
+		expected geom.MultiPointMSetter
+		err      error
+	}
+	fn := func(t *testing.T, tc tcase) {
+		err := tc.setter.SetPoints(tc.points)
+		if tc.err == nil && err != nil {
+			t.Errorf("error, expected nil got %v", err)
+			return
+		}
+		if tc.err != nil {
+			if tc.err.Error() != err.Error() {
+				t.Errorf("error, expected %v got %v", tc.err, err)
+			}
+			return
+		}
+
+		// compare the results
+		if !reflect.DeepEqual(tc.expected, tc.setter) {
+			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+		}
+		pts := tc.setter.Points()
+		if !reflect.DeepEqual(tc.points, pts) {
+			t.Errorf("PointMs, expected %v got %v", tc.points, pts)
+		}
+	}
+	tests := []tcase{
+		{
+			points: [][3]float64{
+				{15, 20, 30},
+				{35, 40, 50},
+				{-15, -5, 0},
+			},
+			setter: &geom.MultiPointM{
+				{10, 20, 30},
+				{30, 40, 50},
+				{-10, -5, 0},
+			},
+			expected: &geom.MultiPointM{
+				{15, 20, 30},
+				{35, 40, 50},
+				{-15, -5, 0},
+			},
+		},
+		{
+			setter: (*geom.MultiPointM)(nil),
+			err:    geom.ErrNilMultiPointM,
+		},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+	}
+}

--- a/multi_pointms.go
+++ b/multi_pointms.go
@@ -1,0 +1,36 @@
+package geom
+
+import "errors"
+
+// ErrNilMultiPointMS is thrown when a MultiPointMS is nil but shouldn't be
+var ErrNilMultiPointMS = errors.New("geom: nil MultiPointMS")
+
+// MultiPointMS is a geometry with multiple, referenced 2+1D points.
+type MultiPointMS struct {
+	Srid uint32
+	Mpm  MultiPointM
+}
+
+// Points returns the coordinates for the 3D points
+func (mpms MultiPointMS) Points() struct {
+	Srid uint32
+	Mpm  MultiPointM
+} {
+	return mpms
+}
+
+// SetSRID modifies the struct containing the SRID int and the array of 3D coordinates
+func (mpms *MultiPointMS) SetSRID(srid uint32, mpm MultiPointM) (err error) {
+	if mpms == nil {
+		return ErrNilMultiPointMS
+	}
+
+	mpms.Srid = srid
+	mpms.Mpm = mpm
+	return
+}
+
+// Get the simple 3D multipoint
+func (mpms MultiPointMS) MultiPointM() MultiPointM {
+	return mpms.Mpm
+}

--- a/multi_pointms_test.go
+++ b/multi_pointms_test.go
@@ -1,0 +1,62 @@
+package geom_test
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/go-spatial/geom"
+)
+
+func TestMultiPointMSSetter(t *testing.T) {
+	type tcase struct {
+		srid        uint32
+		multipointm geom.MultiPointM
+		setter      geom.MultiPointMSSetter
+		expected    geom.MultiPointMSSetter
+		err         error
+	}
+	fn := func(t *testing.T, tc tcase) {
+		err := tc.setter.SetSRID(tc.srid, tc.multipointm)
+		if tc.err == nil && err != nil {
+			t.Errorf("error, expected nil got %v", err)
+			return
+		}
+		if tc.err != nil {
+			if tc.err.Error() != err.Error() {
+				t.Errorf("error, expected %v got %v", tc.err, err)
+			}
+			return
+		}
+
+		// compare the results
+		if !reflect.DeepEqual(tc.expected, tc.setter) {
+			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+		}
+
+		ptms := tc.setter.Points()
+		tc_ptms := struct {
+			Srid uint32
+			Mpm  geom.MultiPointM
+		}{tc.srid, tc.multipointm}
+		if !reflect.DeepEqual(tc_ptms, ptms) {
+			t.Errorf("PointMSs, expected %v got %v", tc_ptms, ptms)
+		}
+	}
+	tests := []tcase{
+		{
+			srid:        4326,
+			multipointm: geom.MultiPointM{{10, 20, 30}, {30, 40, 50}, {-10, -5, 0}},
+			setter:      &geom.MultiPointMS{Srid: 4326, Mpm: geom.MultiPointM{{15, 20, 30}, {35, 40, 50}, {-15, -5, 0}}},
+			expected:    &geom.MultiPointMS{Srid: 4326, Mpm: geom.MultiPointM{{10, 20, 30}, {30, 40, 50}, {-10, -5, 0}}},
+		},
+		{
+			setter: (*geom.MultiPointMS)(nil),
+			err:    geom.ErrNilMultiPointMS,
+		},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+	}
+}

--- a/multi_points.go
+++ b/multi_points.go
@@ -1,0 +1,36 @@
+package geom
+
+import "errors"
+
+// ErrNilMultiPointS is thrown when a MultiPointS is nil but shouldn't be
+var ErrNilMultiPointS = errors.New("geom: nil MultiPointS")
+
+// MultiPointS is a geometry with multiple, referenced 2D points.
+type MultiPointS struct {
+	Srid uint32
+	Mp   MultiPoint
+}
+
+// Points returns the coordinates for the 2D points
+func (mps MultiPointS) Points() struct {
+	Srid uint32
+	Mp   MultiPoint
+} {
+	return mps
+}
+
+// SetSRID modifies the struct containing the SRID int and the array of 2D coordinates
+func (mps *MultiPointS) SetSRID(srid uint32, mp MultiPoint) (err error) {
+	if mps == nil {
+		return ErrNilMultiPointS
+	}
+
+	mps.Srid = srid
+	mps.Mp = mp
+	return
+}
+
+// Get the simple 2D multipoint
+func (mps MultiPointS) MultiPoint() MultiPoint {
+	return mps.Mp
+}

--- a/multi_points_test.go
+++ b/multi_points_test.go
@@ -1,0 +1,62 @@
+package geom_test
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/go-spatial/geom"
+)
+
+func TestMultiPointSSetter(t *testing.T) {
+	type tcase struct {
+		srid       uint32
+		multipoint geom.MultiPoint
+		setter     geom.MultiPointSSetter
+		expected   geom.MultiPointSSetter
+		err        error
+	}
+	fn := func(t *testing.T, tc tcase) {
+		err := tc.setter.SetSRID(tc.srid, tc.multipoint)
+		if tc.err == nil && err != nil {
+			t.Errorf("error, expected nil got %v", err)
+			return
+		}
+		if tc.err != nil {
+			if tc.err.Error() != err.Error() {
+				t.Errorf("error, expected %v got %v", tc.err, err)
+			}
+			return
+		}
+
+		// compare the results
+		if !reflect.DeepEqual(tc.expected, tc.setter) {
+			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+		}
+
+		pts := tc.setter.Points()
+		tc_pts := struct {
+			Srid uint32
+			Mp   geom.MultiPoint
+		}{tc.srid, tc.multipoint}
+		if !reflect.DeepEqual(tc_pts, pts) {
+			t.Errorf("PointSs, expected %v got %v", tc_pts, pts)
+		}
+	}
+	tests := []tcase{
+		{
+			srid:       4326,
+			multipoint: geom.MultiPoint{{10, 20}, {30, 40}, {-10, -5}},
+			setter:     &geom.MultiPointS{Srid: 4326, Mp: geom.MultiPoint{{15, 20}, {35, 40}, {-15, -5}}},
+			expected:   &geom.MultiPointS{Srid: 4326, Mp: geom.MultiPoint{{10, 20}, {30, 40}, {-10, -5}}},
+		},
+		{
+			setter: (*geom.MultiPointS)(nil),
+			err:    geom.ErrNilMultiPointS,
+		},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+	}
+}

--- a/multi_pointz.go
+++ b/multi_pointz.go
@@ -1,0 +1,38 @@
+package geom
+
+import "errors"
+
+// ErrNilMultiPointZ is thrown when a MultiPointZ is nil but shouldn't be
+var ErrNilMultiPointZ = errors.New("geom: nil MultiPointZ")
+
+// MultiPointZ is a geometry with multiple 3D points.
+type MultiPointZ [][3]float64
+
+// Points returns the coordinates for the 3D points
+func (mpz MultiPointZ) Points() [][3]float64 {
+	return mpz
+}
+
+// SetPoints modifies the array of 3D coordinates
+func (mpz *MultiPointZ) SetPoints(input [][3]float64) (err error) {
+	if mpz == nil {
+		return ErrNilMultiPointZ
+	}
+
+	*mpz = append((*mpz)[:0], input...)
+	return
+}
+
+// Get the simple 2D multipoint
+func (mpz MultiPointZ) MultiPoint() MultiPoint {
+	var mpv [][2]float64
+	var mp MultiPoint
+
+	points := mpz.Points()
+	for i := 0; i < len(points); i++ {
+		mpv = append(mpv, [2]float64{points[i][0], points[i][1]})
+	}
+
+	mp.SetPoints(mpv)
+	return mp
+}

--- a/multi_pointz_test.go
+++ b/multi_pointz_test.go
@@ -1,0 +1,67 @@
+package geom_test
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/go-spatial/geom"
+)
+
+func TestMultiPointZSetter(t *testing.T) {
+	type tcase struct {
+		points   [][3]float64
+		setter   geom.MultiPointZSetter
+		expected geom.MultiPointZSetter
+		err      error
+	}
+	fn := func(t *testing.T, tc tcase) {
+		err := tc.setter.SetPoints(tc.points)
+		if tc.err == nil && err != nil {
+			t.Errorf("error, expected nil got %v", err)
+			return
+		}
+		if tc.err != nil {
+			if tc.err.Error() != err.Error() {
+				t.Errorf("error, expected %v got %v", tc.err, err)
+			}
+			return
+		}
+
+		// compare the results
+		if !reflect.DeepEqual(tc.expected, tc.setter) {
+			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+		}
+		pts := tc.setter.Points()
+		if !reflect.DeepEqual(tc.points, pts) {
+			t.Errorf("PointZs, expected %v got %v", tc.points, pts)
+		}
+	}
+	tests := []tcase{
+		{
+			points: [][3]float64{
+				{15, 20, 30},
+				{35, 40, 50},
+				{-15, -5, 0},
+			},
+			setter: &geom.MultiPointZ{
+				{10, 20, 30},
+				{30, 40, 50},
+				{-10, -5, 0},
+			},
+			expected: &geom.MultiPointZ{
+				{15, 20, 30},
+				{35, 40, 50},
+				{-15, -5, 0},
+			},
+		},
+		{
+			setter: (*geom.MultiPointZ)(nil),
+			err:    geom.ErrNilMultiPointZ,
+		},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+	}
+}

--- a/multi_pointzm.go
+++ b/multi_pointzm.go
@@ -1,0 +1,38 @@
+package geom
+
+import "errors"
+
+// ErrNilMultiPointZM is thrown when a MultiPointZM is nil but shouldn't be
+var ErrNilMultiPointZM = errors.New("geom: nil MultiPointZM")
+
+// MultiPointZM is a geometry with multiple 3+1D points.
+type MultiPointZM [][4]float64
+
+// Points returns the coordinates for the 3+1D points
+func (mpzm MultiPointZM) Points() [][4]float64 {
+	return mpzm
+}
+
+// SetPoints modifies the array of 3+1D coordinates
+func (mpzm *MultiPointZM) SetPoints(input [][4]float64) (err error) {
+	if mpzm == nil {
+		return ErrNilMultiPointZM
+	}
+
+	*mpzm = append((*mpzm)[:0], input...)
+	return
+}
+
+// Get the simple 2D multipoint
+func (mpzm MultiPointZM) MultiPoint() MultiPoint {
+	var mpv [][2]float64
+	var mp MultiPoint
+
+	points := mpzm.Points()
+	for i := 0; i < len(points); i++ {
+		mpv = append(mpv, [2]float64{points[i][0], points[i][1]})
+	}
+
+	mp.SetPoints(mpv)
+	return mp
+}

--- a/multi_pointzm_test.go
+++ b/multi_pointzm_test.go
@@ -1,0 +1,67 @@
+package geom_test
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/go-spatial/geom"
+)
+
+func TestMultiPointZMSetter(t *testing.T) {
+	type tcase struct {
+		points   [][4]float64
+		setter   geom.MultiPointZMSetter
+		expected geom.MultiPointZMSetter
+		err      error
+	}
+	fn := func(t *testing.T, tc tcase) {
+		err := tc.setter.SetPoints(tc.points)
+		if tc.err == nil && err != nil {
+			t.Errorf("error, expected nil got %v", err)
+			return
+		}
+		if tc.err != nil {
+			if tc.err.Error() != err.Error() {
+				t.Errorf("error, expected %v got %v", tc.err, err)
+			}
+			return
+		}
+
+		// compare the results
+		if !reflect.DeepEqual(tc.expected, tc.setter) {
+			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+		}
+		pts := tc.setter.Points()
+		if !reflect.DeepEqual(tc.points, pts) {
+			t.Errorf("PointZMs, expected %v got %v", tc.points, pts)
+		}
+	}
+	tests := []tcase{
+		{
+			points: [][4]float64{
+				{15, 20, 30, 40},
+				{35, 40, 50, 60},
+				{-15, -5, 0, 5},
+			},
+			setter: &geom.MultiPointZM{
+				{10, 20, 30, 40},
+				{30, 40, 50, 60},
+				{-10, -5, 0, 5},
+			},
+			expected: &geom.MultiPointZM{
+				{15, 20, 30, 40},
+				{35, 40, 50, 60},
+				{-15, -5, 0, 5},
+			},
+		},
+		{
+			setter: (*geom.MultiPointZM)(nil),
+			err:    geom.ErrNilMultiPointZM,
+		},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+	}
+}

--- a/multi_pointzms.go
+++ b/multi_pointzms.go
@@ -1,0 +1,36 @@
+package geom
+
+import "errors"
+
+// ErrNilMultiPointZMS is thrown when a MultiPointZMS is nil but shouldn't be
+var ErrNilMultiPointZMS = errors.New("geom: nil MultiPointZMS")
+
+// MultiPointZMS is a geometry with multiple, referenced 3+1D points.
+type MultiPointZMS struct {
+	Srid uint32
+	Mpzm MultiPointZM
+}
+
+// Points returns the coordinates for the 3+1D points
+func (mpzms MultiPointZMS) Points() struct {
+	Srid uint32
+	Mpzm MultiPointZM
+} {
+	return mpzms
+}
+
+// SetSRID modifies the struct containing the SRID int and the array of 3+1D coordinates
+func (mpzms *MultiPointZMS) SetSRID(srid uint32, mpzm MultiPointZM) (err error) {
+	if mpzms == nil {
+		return ErrNilMultiPointZMS
+	}
+
+	mpzms.Srid = srid
+	mpzms.Mpzm = mpzm
+	return
+}
+
+// Get the simple 3D multipoint
+func (mpzms MultiPointZMS) MultiPointZM() MultiPointZM {
+	return mpzms.Mpzm
+}

--- a/multi_pointzms_test.go
+++ b/multi_pointzms_test.go
@@ -1,0 +1,62 @@
+package geom_test
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/go-spatial/geom"
+)
+
+func TestMultiPointZMSSetter(t *testing.T) {
+	type tcase struct {
+		srid         uint32
+		multipointzm geom.MultiPointZM
+		setter       geom.MultiPointZMSSetter
+		expected     geom.MultiPointZMSSetter
+		err          error
+	}
+	fn := func(t *testing.T, tc tcase) {
+		err := tc.setter.SetSRID(tc.srid, tc.multipointzm)
+		if tc.err == nil && err != nil {
+			t.Errorf("error, expected nil got %v", err)
+			return
+		}
+		if tc.err != nil {
+			if tc.err.Error() != err.Error() {
+				t.Errorf("error, expected %v got %v", tc.err, err)
+			}
+			return
+		}
+
+		// compare the results
+		if !reflect.DeepEqual(tc.expected, tc.setter) {
+			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+		}
+
+		ptzms := tc.setter.Points()
+		tc_ptzms := struct {
+			Srid uint32
+			Mpzm geom.MultiPointZM
+		}{tc.srid, tc.multipointzm}
+		if !reflect.DeepEqual(tc_ptzms, ptzms) {
+			t.Errorf("PointZMSs, expected %v got %v", tc_ptzms, ptzms)
+		}
+	}
+	tests := []tcase{
+		{
+			srid:         4326,
+			multipointzm: geom.MultiPointZM{{10, 20, 30, 40}, {30, 40, 50, 60}, {-10, -5, 0, 5}},
+			setter:       &geom.MultiPointZMS{Srid: 4326, Mpzm: geom.MultiPointZM{{15, 20, 30, 40}, {35, 40, 50, 60}, {-15, -5, 0, 5}}},
+			expected:     &geom.MultiPointZMS{Srid: 4326, Mpzm: geom.MultiPointZM{{10, 20, 30, 40}, {30, 40, 50, 60}, {-10, -5, 0, 5}}},
+		},
+		{
+			setter: (*geom.MultiPointZMS)(nil),
+			err:    geom.ErrNilMultiPointZMS,
+		},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+	}
+}

--- a/multi_pointzs.go
+++ b/multi_pointzs.go
@@ -1,0 +1,36 @@
+package geom
+
+import "errors"
+
+// ErrNilMultiPointZS is thrown when a MultiPointZS is nil but shouldn't be
+var ErrNilMultiPointZS = errors.New("geom: nil MultiPointZS")
+
+// MultiPointZS is a geometry with multiple, referenced 3D points.
+type MultiPointZS struct {
+	Srid uint32
+	Mpz  MultiPointZ
+}
+
+// Points returns the coordinates for the 3D points
+func (mpzs MultiPointZS) Points() struct {
+	Srid uint32
+	Mpz  MultiPointZ
+} {
+	return mpzs
+}
+
+// SetSRID modifies the struct containing the SRID int and the array of 3D coordinates
+func (mpzs *MultiPointZS) SetSRID(srid uint32, mpz MultiPointZ) (err error) {
+	if mpzs == nil {
+		return ErrNilMultiPointZS
+	}
+
+	mpzs.Srid = srid
+	mpzs.Mpz = mpz
+	return
+}
+
+// Get the simple 3D multipoint
+func (mps MultiPointZS) MultiPointZ() MultiPointZ {
+	return mps.Mpz
+}

--- a/multi_pointzs_test.go
+++ b/multi_pointzs_test.go
@@ -1,0 +1,62 @@
+package geom_test
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/go-spatial/geom"
+)
+
+func TestMultiPointZSSetter(t *testing.T) {
+	type tcase struct {
+		srid        uint32
+		multipointz geom.MultiPointZ
+		setter      geom.MultiPointZSSetter
+		expected    geom.MultiPointZSSetter
+		err         error
+	}
+	fn := func(t *testing.T, tc tcase) {
+		err := tc.setter.SetSRID(tc.srid, tc.multipointz)
+		if tc.err == nil && err != nil {
+			t.Errorf("error, expected nil got %v", err)
+			return
+		}
+		if tc.err != nil {
+			if tc.err.Error() != err.Error() {
+				t.Errorf("error, expected %v got %v", tc.err, err)
+			}
+			return
+		}
+
+		// compare the results
+		if !reflect.DeepEqual(tc.expected, tc.setter) {
+			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+		}
+
+		ptzs := tc.setter.Points()
+		tc_ptzs := struct {
+			Srid uint32
+			Mpz  geom.MultiPointZ
+		}{tc.srid, tc.multipointz}
+		if !reflect.DeepEqual(tc_ptzs, ptzs) {
+			t.Errorf("PointZSs, expected %v got %v", tc_ptzs, ptzs)
+		}
+	}
+	tests := []tcase{
+		{
+			srid:        4326,
+			multipointz: geom.MultiPointZ{{10, 20, 30}, {30, 40, 50}, {-10, -5, 0}},
+			setter:      &geom.MultiPointZS{Srid: 4326, Mpz: geom.MultiPointZ{{15, 20, 30}, {35, 40, 50}, {-15, -5, 0}}},
+			expected:    &geom.MultiPointZS{Srid: 4326, Mpz: geom.MultiPointZ{{10, 20, 30}, {30, 40, 50}, {-10, -5, 0}}},
+		},
+		{
+			setter: (*geom.MultiPointZS)(nil),
+			err:    geom.ErrNilMultiPointZS,
+		},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+	}
+}

--- a/set_geom.go
+++ b/set_geom.go
@@ -58,6 +58,48 @@ type MultiPointSetter interface {
 	SetPoints([][2]float64) error
 }
 
+// MultiPointZSetter is a mutable MultiPointer.
+type MultiPointZSetter interface {
+	MultiPointZer
+	SetPoints([][3]float64) error
+}
+
+// MultiPointMSetter is a mutable MultiPointer.
+type MultiPointMSetter interface {
+	MultiPointMer
+	SetPoints([][3]float64) error
+}
+
+// MultiPointZMSetter is a mutable MultiPointer.
+type MultiPointZMSetter interface {
+	MultiPointZMer
+	SetPoints([][4]float64) error
+}
+
+// MultiPointSSetter is a mutable MultiPointSer.
+type MultiPointSSetter interface {
+	MultiPointSer
+	SetSRID(srid uint32, mp MultiPoint) error
+}
+
+// MultiPointZSSetter is a mutable MultiPointZSer.
+type MultiPointZSSetter interface {
+	MultiPointZSer
+	SetSRID(srid uint32, mpz MultiPointZ) error
+}
+
+// MultiPointMSSetter is a mutable MultiPointMSer.
+type MultiPointMSSetter interface {
+	MultiPointMSer
+	SetSRID(srid uint32, mpz MultiPointM) error
+}
+
+// MultiPointZMSSetter is a mutable MultiPointZMSer.
+type MultiPointZMSSetter interface {
+	MultiPointZMSer
+	SetSRID(srid uint32, mpzm MultiPointZM) error
+}
+
 // LineStringSetter is a mutable LineStringer.
 type LineStringSetter interface {
 	LineStringer


### PR DESCRIPTION
As made for Point and LineString types, the PR contains the definitions of the extended geometries for MultiPoint type.

As made for LineString, basics methods for the new types have been defined, basically to reduce the extradimensions to 2D objects in order to be integrated with the rest of the repo.