### PR TITLE
Add support for extended MultiLineString geometries

### DIFF
--- a/geom.go
+++ b/geom.go
@@ -196,6 +196,60 @@ type MultiLineStringer interface {
 	LineStrings() [][][2]float64
 }
 
+// MultiLineZStringer is a geometry with multiple LineZStrings.
+type MultiLineStringZer interface {
+	Geometry
+	LineStringZs() [][][3]float64
+}
+
+// MultiLineMStringer is a geometry with multiple LineMStrings.
+type MultiLineStringMer interface {
+	Geometry
+	LineStringMs() [][][3]float64
+}
+
+// MultiLineZMStringer is a geometry with multiple LineZMStrings.
+type MultiLineStringZMer interface {
+	Geometry
+	LineStringZMs() [][][4]float64
+}
+
+// MultiLineSStringer is a geometry with multiple LineSStrings.
+type MultiLineStringSer interface {
+	Geometry
+	MultiLineStrings() struct {
+		Srid uint32
+		Mls  MultiLineString
+	}
+}
+
+// MultiLineZSStringer is a geometry with multiple LineZSStrings.
+type MultiLineStringZSer interface {
+	Geometry
+	MultiLineStringZs() struct {
+		Srid uint32
+		Mlsz MultiLineStringZ
+	}
+}
+
+// MultiLineMSStringer is a geometry with multiple LineMSStrings.
+type MultiLineStringMSer interface {
+	Geometry
+	MultiLineStringMs() struct {
+		Srid uint32
+		Mlsm MultiLineStringM
+	}
+}
+
+// MultiLineZMSStringer is a geometry with multiple LineZMSStrings.
+type MultiLineStringZMSer interface {
+	Geometry
+	MultiLineStringZMs() struct {
+		Srid  uint32
+		Mlszm MultiLineStringZM
+	}
+}
+
 // Polygoner is a geometry consisting of multiple Linear Rings.
 // There must be only one exterior LineString with a clockwise winding order.
 // There may be one or more interior LineStrings with a counterclockwise winding orders.

--- a/line_stringms.go
+++ b/line_stringms.go
@@ -20,7 +20,9 @@ type LineStringMS struct {
 func (lsms LineStringMS) Vertices() struct {
 	Srid uint32
 	Lsm  LineStringM
-} { return lsms }
+} {
+	return lsms
+}
 
 // SetVertices modifies the struct containing the SRID int and the array of 2D + 1 coordinates
 func (lsms *LineStringMS) SetSRID(srid uint32, lsm LineStringM) (err error) {

--- a/line_strings.go
+++ b/line_strings.go
@@ -20,7 +20,9 @@ type LineStringS struct {
 func (lss LineStringS) Vertices() struct {
 	Srid uint32
 	Ls   LineString
-} { return lss }
+} {
+	return lss
+}
 
 // SetVertices modifies the struct containing the SRID int and the array of 2D coordinates
 func (lss *LineStringS) SetSRID(srid uint32, ls LineString) (err error) {

--- a/line_stringzms.go
+++ b/line_stringzms.go
@@ -20,7 +20,9 @@ type LineStringZMS struct {
 func (lszms LineStringZMS) Vertices() struct {
 	Srid uint32
 	Lszm LineStringZM
-} { return lszms }
+} {
+	return lszms
+}
 
 // SetVertices modifies the struct containing the SRID int and the array of 3D + 1 coordinates
 func (lszms *LineStringZMS) SetSRID(srid uint32, lszm LineStringZM) (err error) {

--- a/line_stringzs.go
+++ b/line_stringzs.go
@@ -20,7 +20,9 @@ type LineStringZS struct {
 func (lszs LineStringZS) Vertices() struct {
 	Srid uint32
 	Lsz  LineStringZ
-} { return lszs }
+} {
+	return lszs
+}
 
 // SetVertices modifies the struct containing the SRID int and the array of 3D coordinates
 func (lszs *LineStringZS) SetSRID(srid uint32, lsz LineStringZ) (err error) {

--- a/multi_line_stringm.go
+++ b/multi_line_stringm.go
@@ -1,0 +1,39 @@
+package geom
+
+import "errors"
+
+// ErrNilMultiLineStringM is thrown when MultiLineStringM is nil but shouldn't be
+var ErrNilMultiLineStringM = errors.New("geom: nil MultiLineStringM")
+
+// MultiLineStringM is a geometry with multiple LineStringMs.
+type MultiLineStringM [][][3]float64
+
+// LineStringMs returns the coordinates for the linestrings
+func (mlsm MultiLineStringM) LineStringMs() [][][3]float64 {
+	return mlsm
+}
+
+// SetLineStringZs modifies the array of 2D+1D coordinates
+func (mlsm *MultiLineStringM) SetLineStringMs(input [][][3]float64) (err error) {
+	if mlsm == nil {
+		return ErrNilMultiLineStringM
+	}
+
+	*mlsm = append((*mlsm)[:0], input...)
+	return
+}
+
+// AsSegments returns the multi lines string as a set of lineMs.
+func (mlsm MultiLineStringM) AsLineStringMs() (segs []LineStringM, err error) {
+	if len(mlsm) == 0 {
+		return nil, nil
+	}
+	for i := range mlsm {
+		lsm := LineStringM(mlsm[i])
+		if lsm == nil {
+			return nil, errors.New("geom: error in splitting MultiLineStringM")
+		}
+		segs = append(segs, lsm)
+	}
+	return segs, nil
+}

--- a/multi_line_stringm_test.go
+++ b/multi_line_stringm_test.go
@@ -1,0 +1,83 @@
+package geom_test
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/go-spatial/geom"
+)
+
+func TestMultiLineStringMSetter(t *testing.T) {
+	type tcase struct {
+		pointms  [][][3]float64
+		setter   geom.MultiLineStringMSetter
+		expected geom.MultiLineStringMSetter
+		err      error
+	}
+	fn := func(t *testing.T, tc tcase) {
+		err := tc.setter.SetLineStringMs(tc.pointms)
+		if tc.err == nil && err != nil {
+			t.Errorf("error, expected nil got %v", err)
+			return
+		}
+		if tc.err != nil {
+			if tc.err.Error() != err.Error() {
+				t.Errorf("error, expected %v got %v", tc.err, err)
+			}
+			return
+		}
+
+		// compare the results
+		if !reflect.DeepEqual(tc.expected, tc.setter) {
+			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+		}
+		mlm := tc.setter.LineStringMs()
+		if !reflect.DeepEqual(tc.pointms, mlm) {
+			t.Errorf("LineStringMs, expected %v got %v", tc.pointms, mlm)
+		}
+	}
+	tests := []tcase{
+		{
+			pointms: [][][3]float64{
+				{
+					{15, 20, 30},
+					{35, 40, 50},
+				},
+				{
+					{-15, -5, 0},
+					{20, 20, 20},
+				},
+			},
+			setter: &geom.MultiLineStringM{
+				{
+					{10, 20, 30},
+					{30, 40, 50},
+				},
+				{
+					{-10, -5, 0},
+					{15, 20, 20},
+				},
+			},
+			expected: &geom.MultiLineStringM{
+				{
+					{15, 20, 30},
+					{35, 40, 50},
+				},
+				{
+					{-15, -5, 0},
+					{20, 20, 20},
+				},
+			},
+		},
+		{
+			setter: (*geom.MultiLineStringM)(nil),
+			err:    geom.ErrNilMultiLineStringM,
+		},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+	}
+
+}

--- a/multi_line_stringm_test.go
+++ b/multi_line_stringm_test.go
@@ -15,28 +15,32 @@ func TestMultiLineStringMSetter(t *testing.T) {
 		expected geom.MultiLineStringMSetter
 		err      error
 	}
-	fn := func(t *testing.T, tc tcase) {
-		err := tc.setter.SetLineStringMs(tc.pointms)
-		if tc.err == nil && err != nil {
-			t.Errorf("error, expected nil got %v", err)
-			return
-		}
-		if tc.err != nil {
-			if tc.err.Error() != err.Error() {
-				t.Errorf("error, expected %v got %v", tc.err, err)
-			}
-			return
-		}
 
-		// compare the results
-		if !reflect.DeepEqual(tc.expected, tc.setter) {
-			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
-		}
-		mlm := tc.setter.LineStringMs()
-		if !reflect.DeepEqual(tc.pointms, mlm) {
-			t.Errorf("LineStringMs, expected %v got %v", tc.pointms, mlm)
+	fn := func(tc tcase) func(*testing.T) {
+		return func(t *testing.T) {
+			err := tc.setter.SetLineStringMs(tc.pointms)
+			if tc.err == nil && err != nil {
+				t.Errorf("error, expected nil got %v", err)
+				return
+			}
+			if tc.err != nil {
+				if tc.err.Error() != err.Error() {
+					t.Errorf("error, expected %v got %v", tc.err, err)
+				}
+				return
+			}
+
+			// compare the results
+			if !reflect.DeepEqual(tc.expected, tc.setter) {
+				t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+			}
+			mlm := tc.setter.LineStringMs()
+			if !reflect.DeepEqual(tc.pointms, mlm) {
+				t.Errorf("LineStringMs, expected %v got %v", tc.pointms, mlm)
+			}
 		}
 	}
+
 	tests := []tcase{
 		{
 			pointms: [][][3]float64{
@@ -75,9 +79,9 @@ func TestMultiLineStringMSetter(t *testing.T) {
 			err:    geom.ErrNilMultiLineStringM,
 		},
 	}
-	for i, tc := range tests {
-		tc := tc
-		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+
+	for i := range tests {
+		t.Run(strconv.FormatInt(int64(i), 10), fn(tests[i]))
 	}
 
 }

--- a/multi_line_stringms.go
+++ b/multi_line_stringms.go
@@ -1,0 +1,36 @@
+package geom
+
+import "errors"
+
+// ErrNilMultiLineStringMS is thrown when MultiLineStringMS is nil but shouldn't be
+var ErrNilMultiLineStringMS = errors.New("geom: nil MultiLineStringMS")
+
+// MultiLineStringMS is a geometry with multiple LineStringSs.
+type MultiLineStringMS struct {
+	Srid uint32
+	Mlsm MultiLineStringM
+}
+
+// LineStrings returns the coordinates for the linestrings
+func (mlsms MultiLineStringMS) MultiLineStringMs() struct {
+	Srid uint32
+	Mlsm MultiLineStringM
+} {
+	return mlsms
+}
+
+// SetSRID modifies the struct containing the SRID int and the array of 2D+1 coordinates
+func (mlsms *MultiLineStringMS) SetSRID(srid uint32, mlsm MultiLineStringM) (err error) {
+	if mlsms == nil {
+		return ErrNilMultiLineStringMS
+	}
+
+	mlsms.Srid = srid
+	mlsms.Mlsm = mlsm
+	return
+}
+
+// Get the simple 2D+1 multiline string
+func (mlsms MultiLineStringMS) MultiLineStringM() MultiLineStringM {
+	return mlsms.Mlsm
+}

--- a/multi_line_stringms_test.go
+++ b/multi_line_stringms_test.go
@@ -1,0 +1,94 @@
+package geom_test
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/go-spatial/geom"
+)
+
+func TestMultiLineStringMSSetter(t *testing.T) {
+	type tcase struct {
+		srid             uint32
+		multilinestringm geom.MultiLineStringM
+		setter           geom.MultiLineStringMSSetter
+		expected         geom.MultiLineStringMSSetter
+		err              error
+	}
+	fn := func(t *testing.T, tc tcase) {
+		err := tc.setter.SetSRID(tc.srid, tc.multilinestringm)
+		if tc.err == nil && err != nil {
+			t.Errorf("error, expected nil got %v", err)
+			return
+		}
+		if tc.err != nil {
+			if tc.err.Error() != err.Error() {
+				t.Errorf("error, expected %v got %v", tc.err, err)
+			}
+			return
+		}
+		// compare the results
+		if !reflect.DeepEqual(tc.expected, tc.setter) {
+			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+		}
+
+		mlsms := tc.setter.MultiLineStringMs()
+		tc_mlsms := struct {
+			Srid uint32
+			Mlsm geom.MultiLineStringM
+		}{tc.srid, tc.multilinestringm}
+		if !reflect.DeepEqual(tc_mlsms, mlsms) {
+			t.Errorf("Referenced MultiLineStringM, expected %v got %v", tc_mlsms, mlsms)
+		}
+	}
+	tests := []tcase{
+		{
+			srid: 4326,
+			multilinestringm: geom.MultiLineStringM{
+				{
+					{10, 20, 30},
+					{30, 40, 50},
+				},
+				{
+					{50, 60, 70},
+					{70, 80, 90},
+				},
+			},
+			setter: &geom.MultiLineStringMS{
+				Srid: 4326,
+				Mlsm: geom.MultiLineStringM{
+					{
+						{15, 20, 30},
+						{35, 40, 50},
+					},
+					{
+						{55, 60, 70},
+						{75, 80, 90},
+					},
+				},
+			},
+			expected: &geom.MultiLineStringMS{
+				Srid: 4326,
+				Mlsm: geom.MultiLineStringM{
+					{
+						{10, 20, 30},
+						{30, 40, 50},
+					},
+					{
+						{50, 60, 70},
+						{70, 80, 90},
+					},
+				},
+			},
+		},
+		{
+			setter: (*geom.MultiLineStringMS)(nil),
+			err:    geom.ErrNilMultiLineStringMS,
+		},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+	}
+}

--- a/multi_line_stringms_test.go
+++ b/multi_line_stringms_test.go
@@ -16,32 +16,36 @@ func TestMultiLineStringMSSetter(t *testing.T) {
 		expected         geom.MultiLineStringMSSetter
 		err              error
 	}
-	fn := func(t *testing.T, tc tcase) {
-		err := tc.setter.SetSRID(tc.srid, tc.multilinestringm)
-		if tc.err == nil && err != nil {
-			t.Errorf("error, expected nil got %v", err)
-			return
-		}
-		if tc.err != nil {
-			if tc.err.Error() != err.Error() {
-				t.Errorf("error, expected %v got %v", tc.err, err)
-			}
-			return
-		}
-		// compare the results
-		if !reflect.DeepEqual(tc.expected, tc.setter) {
-			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
-		}
 
-		mlsms := tc.setter.MultiLineStringMs()
-		tc_mlsms := struct {
-			Srid uint32
-			Mlsm geom.MultiLineStringM
-		}{tc.srid, tc.multilinestringm}
-		if !reflect.DeepEqual(tc_mlsms, mlsms) {
-			t.Errorf("Referenced MultiLineStringM, expected %v got %v", tc_mlsms, mlsms)
+	fn := func(tc tcase) func(*testing.T) {
+		return func(t *testing.T) {
+			err := tc.setter.SetSRID(tc.srid, tc.multilinestringm)
+			if tc.err == nil && err != nil {
+				t.Errorf("error, expected nil got %v", err)
+				return
+			}
+			if tc.err != nil {
+				if tc.err.Error() != err.Error() {
+					t.Errorf("error, expected %v got %v", tc.err, err)
+				}
+				return
+			}
+			// compare the results
+			if !reflect.DeepEqual(tc.expected, tc.setter) {
+				t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+			}
+
+			mlsms := tc.setter.MultiLineStringMs()
+			tc_mlsms := struct {
+				Srid uint32
+				Mlsm geom.MultiLineStringM
+			}{tc.srid, tc.multilinestringm}
+			if !reflect.DeepEqual(tc_mlsms, mlsms) {
+				t.Errorf("Referenced MultiLineStringM, expected %v got %v", tc_mlsms, mlsms)
+			}
 		}
 	}
+
 	tests := []tcase{
 		{
 			srid: 4326,
@@ -87,8 +91,8 @@ func TestMultiLineStringMSSetter(t *testing.T) {
 			err:    geom.ErrNilMultiLineStringMS,
 		},
 	}
-	for i, tc := range tests {
-		tc := tc
-		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+
+	for i := range tests {
+		t.Run(strconv.FormatInt(int64(i), 10), fn(tests[i]))
 	}
 }

--- a/multi_line_strings.go
+++ b/multi_line_strings.go
@@ -1,0 +1,36 @@
+package geom
+
+import "errors"
+
+// ErrNilMultiLineStringS is thrown when MultiLineStringS is nil but shouldn't be
+var ErrNilMultiLineStringS = errors.New("geom: nil MultiLineStringS")
+
+// MultiLineStringS is a geometry with multiple LineStringSs.
+type MultiLineStringS struct {
+	Srid uint32
+	Mls  MultiLineString
+}
+
+// LineStrings returns the coordinates for the linestrings
+func (mlss MultiLineStringS) MultiLineStrings() struct {
+	Srid uint32
+	Mls  MultiLineString
+} {
+	return mlss
+}
+
+// SetSRID modifies the struct containing the SRID int and the array of 2D coordinates
+func (mlss *MultiLineStringS) SetSRID(srid uint32, mls MultiLineString) (err error) {
+	if mlss == nil {
+		return ErrNilMultiLineStringS
+	}
+
+	mlss.Srid = srid
+	mlss.Mls = mls
+	return
+}
+
+// Get the simple 2D multiline string
+func (mlss MultiLineStringS) MultiLineString() MultiLineString {
+	return mlss.Mls
+}

--- a/multi_line_strings_test.go
+++ b/multi_line_strings_test.go
@@ -1,0 +1,94 @@
+package geom_test
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/go-spatial/geom"
+)
+
+func TestMultiLineStringSSetter(t *testing.T) {
+	type tcase struct {
+		srid            uint32
+		multilinestring geom.MultiLineString
+		setter          geom.MultiLineStringSSetter
+		expected        geom.MultiLineStringSSetter
+		err             error
+	}
+	fn := func(t *testing.T, tc tcase) {
+		err := tc.setter.SetSRID(tc.srid, tc.multilinestring)
+		if tc.err == nil && err != nil {
+			t.Errorf("error, expected nil got %v", err)
+			return
+		}
+		if tc.err != nil {
+			if tc.err.Error() != err.Error() {
+				t.Errorf("error, expected %v got %v", tc.err, err)
+			}
+			return
+		}
+		// compare the results
+		if !reflect.DeepEqual(tc.expected, tc.setter) {
+			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+		}
+
+		mlss := tc.setter.MultiLineStrings()
+		tc_mlss := struct {
+			Srid uint32
+			Mls  geom.MultiLineString
+		}{tc.srid, tc.multilinestring}
+		if !reflect.DeepEqual(tc_mlss, mlss) {
+			t.Errorf("Referenced MultiLineString, expected %v got %v", tc_mlss, mlss)
+		}
+	}
+	tests := []tcase{
+		{
+			srid: 4326,
+			multilinestring: geom.MultiLineString{
+				{
+					{10, 20},
+					{30, 40},
+				},
+				{
+					{50, 60},
+					{70, 80},
+				},
+			},
+			setter: &geom.MultiLineStringS{
+				Srid: 4326,
+				Mls: geom.MultiLineString{
+					{
+						{15, 20},
+						{35, 40},
+					},
+					{
+						{55, 60},
+						{75, 80},
+					},
+				},
+			},
+			expected: &geom.MultiLineStringS{
+				Srid: 4326,
+				Mls: geom.MultiLineString{
+					{
+						{10, 20},
+						{30, 40},
+					},
+					{
+						{50, 60},
+						{70, 80},
+					},
+				},
+			},
+		},
+		{
+			setter: (*geom.MultiLineStringS)(nil),
+			err:    geom.ErrNilMultiLineStringS,
+		},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+	}
+}

--- a/multi_line_strings_test.go
+++ b/multi_line_strings_test.go
@@ -16,32 +16,36 @@ func TestMultiLineStringSSetter(t *testing.T) {
 		expected        geom.MultiLineStringSSetter
 		err             error
 	}
-	fn := func(t *testing.T, tc tcase) {
-		err := tc.setter.SetSRID(tc.srid, tc.multilinestring)
-		if tc.err == nil && err != nil {
-			t.Errorf("error, expected nil got %v", err)
-			return
-		}
-		if tc.err != nil {
-			if tc.err.Error() != err.Error() {
-				t.Errorf("error, expected %v got %v", tc.err, err)
-			}
-			return
-		}
-		// compare the results
-		if !reflect.DeepEqual(tc.expected, tc.setter) {
-			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
-		}
 
-		mlss := tc.setter.MultiLineStrings()
-		tc_mlss := struct {
-			Srid uint32
-			Mls  geom.MultiLineString
-		}{tc.srid, tc.multilinestring}
-		if !reflect.DeepEqual(tc_mlss, mlss) {
-			t.Errorf("Referenced MultiLineString, expected %v got %v", tc_mlss, mlss)
+	fn := func(tc tcase) func(*testing.T) {
+		return func(t *testing.T) {
+			err := tc.setter.SetSRID(tc.srid, tc.multilinestring)
+			if tc.err == nil && err != nil {
+				t.Errorf("error, expected nil got %v", err)
+				return
+			}
+			if tc.err != nil {
+				if tc.err.Error() != err.Error() {
+					t.Errorf("error, expected %v got %v", tc.err, err)
+				}
+				return
+			}
+			// compare the results
+			if !reflect.DeepEqual(tc.expected, tc.setter) {
+				t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+			}
+
+			mlss := tc.setter.MultiLineStrings()
+			tc_mlss := struct {
+				Srid uint32
+				Mls  geom.MultiLineString
+			}{tc.srid, tc.multilinestring}
+			if !reflect.DeepEqual(tc_mlss, mlss) {
+				t.Errorf("Referenced MultiLineString, expected %v got %v", tc_mlss, mlss)
+			}
 		}
 	}
+
 	tests := []tcase{
 		{
 			srid: 4326,
@@ -87,8 +91,8 @@ func TestMultiLineStringSSetter(t *testing.T) {
 			err:    geom.ErrNilMultiLineStringS,
 		},
 	}
-	for i, tc := range tests {
-		tc := tc
-		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+
+	for i := range tests {
+		t.Run(strconv.FormatInt(int64(i), 10), fn(tests[i]))
 	}
 }

--- a/multi_line_stringz.go
+++ b/multi_line_stringz.go
@@ -1,0 +1,39 @@
+package geom
+
+import "errors"
+
+// ErrNilMultiLineStringZ is thrown when MultiLineStringZ is nil but shouldn't be
+var ErrNilMultiLineStringZ = errors.New("geom: nil MultiLineStringZ")
+
+// MultiLineStringZ is a geometry with multiple LineStringZs.
+type MultiLineStringZ [][][3]float64
+
+// LineStringZs returns the coordinates for the linestrings
+func (mlsz MultiLineStringZ) LineStringZs() [][][3]float64 {
+	return mlsz
+}
+
+// SetLineStringZs modifies the array of 3D coordinates
+func (mlsz *MultiLineStringZ) SetLineStringZs(input [][][3]float64) (err error) {
+	if mlsz == nil {
+		return ErrNilMultiLineStringZ
+	}
+
+	*mlsz = append((*mlsz)[:0], input...)
+	return
+}
+
+// AsSegments returns the multi lines string as a set of lineZs.
+func (mlsz MultiLineStringZ) AsLineStringZs() (segs []LineStringZ, err error) {
+	if len(mlsz) == 0 {
+		return nil, nil
+	}
+	for i := range mlsz {
+		lsz := LineStringZ(mlsz[i])
+		if lsz == nil {
+			return nil, errors.New("geom: error in splitting MultiLineStringZ")
+		}
+		segs = append(segs, lsz)
+	}
+	return segs, nil
+}

--- a/multi_line_stringz_test.go
+++ b/multi_line_stringz_test.go
@@ -15,28 +15,32 @@ func TestMultiLineStringZSetter(t *testing.T) {
 		expected geom.MultiLineStringZSetter
 		err      error
 	}
-	fn := func(t *testing.T, tc tcase) {
-		err := tc.setter.SetLineStringZs(tc.pointzs)
-		if tc.err == nil && err != nil {
-			t.Errorf("error, expected nil got %v", err)
-			return
-		}
-		if tc.err != nil {
-			if tc.err.Error() != err.Error() {
-				t.Errorf("error, expected %v got %v", tc.err, err)
-			}
-			return
-		}
 
-		// compare the results
-		if !reflect.DeepEqual(tc.expected, tc.setter) {
-			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
-		}
-		mlz := tc.setter.LineStringZs()
-		if !reflect.DeepEqual(tc.pointzs, mlz) {
-			t.Errorf("LineStringZs, expected %v got %v", tc.pointzs, mlz)
+	fn := func(tc tcase) func(*testing.T) {
+		return func(t *testing.T) {
+			err := tc.setter.SetLineStringZs(tc.pointzs)
+			if tc.err == nil && err != nil {
+				t.Errorf("error, expected nil got %v", err)
+				return
+			}
+			if tc.err != nil {
+				if tc.err.Error() != err.Error() {
+					t.Errorf("error, expected %v got %v", tc.err, err)
+				}
+				return
+			}
+
+			// compare the results
+			if !reflect.DeepEqual(tc.expected, tc.setter) {
+				t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+			}
+			mlz := tc.setter.LineStringZs()
+			if !reflect.DeepEqual(tc.pointzs, mlz) {
+				t.Errorf("LineStringZs, expected %v got %v", tc.pointzs, mlz)
+			}
 		}
 	}
+
 	tests := []tcase{
 		{
 			pointzs: [][][3]float64{
@@ -75,9 +79,9 @@ func TestMultiLineStringZSetter(t *testing.T) {
 			err:    geom.ErrNilMultiLineStringZ,
 		},
 	}
-	for i, tc := range tests {
-		tc := tc
-		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+
+	for i := range tests {
+		t.Run(strconv.FormatInt(int64(i), 10), fn(tests[i]))
 	}
 
 }

--- a/multi_line_stringz_test.go
+++ b/multi_line_stringz_test.go
@@ -1,0 +1,83 @@
+package geom_test
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/go-spatial/geom"
+)
+
+func TestMultiLineStringZSetter(t *testing.T) {
+	type tcase struct {
+		pointzs  [][][3]float64
+		setter   geom.MultiLineStringZSetter
+		expected geom.MultiLineStringZSetter
+		err      error
+	}
+	fn := func(t *testing.T, tc tcase) {
+		err := tc.setter.SetLineStringZs(tc.pointzs)
+		if tc.err == nil && err != nil {
+			t.Errorf("error, expected nil got %v", err)
+			return
+		}
+		if tc.err != nil {
+			if tc.err.Error() != err.Error() {
+				t.Errorf("error, expected %v got %v", tc.err, err)
+			}
+			return
+		}
+
+		// compare the results
+		if !reflect.DeepEqual(tc.expected, tc.setter) {
+			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+		}
+		mlz := tc.setter.LineStringZs()
+		if !reflect.DeepEqual(tc.pointzs, mlz) {
+			t.Errorf("LineStringZs, expected %v got %v", tc.pointzs, mlz)
+		}
+	}
+	tests := []tcase{
+		{
+			pointzs: [][][3]float64{
+				{
+					{15, 20, 30},
+					{35, 40, 50},
+				},
+				{
+					{-15, -5, 0},
+					{20, 20, 20},
+				},
+			},
+			setter: &geom.MultiLineStringZ{
+				{
+					{10, 20, 30},
+					{30, 40, 50},
+				},
+				{
+					{-10, -5, 0},
+					{15, 20, 20},
+				},
+			},
+			expected: &geom.MultiLineStringZ{
+				{
+					{15, 20, 30},
+					{35, 40, 50},
+				},
+				{
+					{-15, -5, 0},
+					{20, 20, 20},
+				},
+			},
+		},
+		{
+			setter: (*geom.MultiLineStringZ)(nil),
+			err:    geom.ErrNilMultiLineStringZ,
+		},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+	}
+
+}

--- a/multi_line_stringzm.go
+++ b/multi_line_stringzm.go
@@ -1,0 +1,39 @@
+package geom
+
+import "errors"
+
+// ErrNilMultiLineStringZM is thrown when MultiLineStringZM is nil but shouldn't be
+var ErrNilMultiLineStringZM = errors.New("geom: nil MultiLineStringZM")
+
+// MultiLineStringZM is a geometry with multiple LineStringZMs.
+type MultiLineStringZM [][][4]float64
+
+// LineStringZMs returns the coordinates for the linestrings
+func (mlszm MultiLineStringZM) LineStringZMs() [][][4]float64 {
+	return mlszm
+}
+
+// SetLineStringZMs modifies the array of 3D+1D coordinates
+func (mlszm *MultiLineStringZM) SetLineStringZMs(input [][][4]float64) (err error) {
+	if mlszm == nil {
+		return ErrNilMultiLineStringZM
+	}
+
+	*mlszm = append((*mlszm)[:0], input...)
+	return
+}
+
+// AsSegments returns the multi lines string as a set of lineZMs.
+func (mlszm MultiLineStringZM) AsLineStringZMs() (segs []LineStringZM, err error) {
+	if len(mlszm) == 0 {
+		return nil, nil
+	}
+	for i := range mlszm {
+		lszm := LineStringZM(mlszm[i])
+		if lszm == nil {
+			return nil, errors.New("geom: error in splitting MultiLineStringZM")
+		}
+		segs = append(segs, lszm)
+	}
+	return segs, nil
+}

--- a/multi_line_stringzm_test.go
+++ b/multi_line_stringzm_test.go
@@ -1,0 +1,83 @@
+package geom_test
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/go-spatial/geom"
+)
+
+func TestMultiLineStringZMSetter(t *testing.T) {
+	type tcase struct {
+		pointzms [][][4]float64
+		setter   geom.MultiLineStringZMSetter
+		expected geom.MultiLineStringZMSetter
+		err      error
+	}
+	fn := func(t *testing.T, tc tcase) {
+		err := tc.setter.SetLineStringZMs(tc.pointzms)
+		if tc.err == nil && err != nil {
+			t.Errorf("error, expected nil got %v", err)
+			return
+		}
+		if tc.err != nil {
+			if tc.err.Error() != err.Error() {
+				t.Errorf("error, expected %v got %v", tc.err, err)
+			}
+			return
+		}
+
+		// compare the results
+		if !reflect.DeepEqual(tc.expected, tc.setter) {
+			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+		}
+		mlzm := tc.setter.LineStringZMs()
+		if !reflect.DeepEqual(tc.pointzms, mlzm) {
+			t.Errorf("LineStringZMs, expected %v got %v", tc.pointzms, mlzm)
+		}
+	}
+	tests := []tcase{
+		{
+			pointzms: [][][4]float64{
+				{
+					{15, 20, 30, 40},
+					{35, 40, 50, 60},
+				},
+				{
+					{-15, -5, 0, 5},
+					{20, 20, 20, 20},
+				},
+			},
+			setter: &geom.MultiLineStringZM{
+				{
+					{10, 20, 30, 40},
+					{30, 40, 50, 60},
+				},
+				{
+					{-10, -5, 0, 5},
+					{15, 20, 20, 20},
+				},
+			},
+			expected: &geom.MultiLineStringZM{
+				{
+					{15, 20, 30, 40},
+					{35, 40, 50, 60},
+				},
+				{
+					{-15, -5, 0, 5},
+					{20, 20, 20, 20},
+				},
+			},
+		},
+		{
+			setter: (*geom.MultiLineStringZM)(nil),
+			err:    geom.ErrNilMultiLineStringZM,
+		},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+	}
+
+}

--- a/multi_line_stringzm_test.go
+++ b/multi_line_stringzm_test.go
@@ -15,26 +15,29 @@ func TestMultiLineStringZMSetter(t *testing.T) {
 		expected geom.MultiLineStringZMSetter
 		err      error
 	}
-	fn := func(t *testing.T, tc tcase) {
-		err := tc.setter.SetLineStringZMs(tc.pointzms)
-		if tc.err == nil && err != nil {
-			t.Errorf("error, expected nil got %v", err)
-			return
-		}
-		if tc.err != nil {
-			if tc.err.Error() != err.Error() {
-				t.Errorf("error, expected %v got %v", tc.err, err)
-			}
-			return
-		}
 
-		// compare the results
-		if !reflect.DeepEqual(tc.expected, tc.setter) {
-			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
-		}
-		mlzm := tc.setter.LineStringZMs()
-		if !reflect.DeepEqual(tc.pointzms, mlzm) {
-			t.Errorf("LineStringZMs, expected %v got %v", tc.pointzms, mlzm)
+	fn := func(tc tcase) func(*testing.T) {
+		return func(t *testing.T) {
+			err := tc.setter.SetLineStringZMs(tc.pointzms)
+			if tc.err == nil && err != nil {
+				t.Errorf("error, expected nil got %v", err)
+				return
+			}
+			if tc.err != nil {
+				if tc.err.Error() != err.Error() {
+					t.Errorf("error, expected %v got %v", tc.err, err)
+				}
+				return
+			}
+
+			// compare the results
+			if !reflect.DeepEqual(tc.expected, tc.setter) {
+				t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+			}
+			mlzm := tc.setter.LineStringZMs()
+			if !reflect.DeepEqual(tc.pointzms, mlzm) {
+				t.Errorf("LineStringZMs, expected %v got %v", tc.pointzms, mlzm)
+			}
 		}
 	}
 	tests := []tcase{
@@ -75,9 +78,9 @@ func TestMultiLineStringZMSetter(t *testing.T) {
 			err:    geom.ErrNilMultiLineStringZM,
 		},
 	}
-	for i, tc := range tests {
-		tc := tc
-		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+
+	for i := range tests {
+		t.Run(strconv.FormatInt(int64(i), 10), fn(tests[i]))
 	}
 
 }

--- a/multi_line_stringzms.go
+++ b/multi_line_stringzms.go
@@ -1,0 +1,36 @@
+package geom
+
+import "errors"
+
+// ErrNilMultiLineStringZMS is thrown when MultiLineStringZMS is nil but shouldn't be
+var ErrNilMultiLineStringZMS = errors.New("geom: nil MultiLineStringZMS")
+
+// MultiLineStringZMS is a geometry with multiple LineStringSs.
+type MultiLineStringZMS struct {
+	Srid  uint32
+	Mlszm MultiLineStringZM
+}
+
+// LineStrings returns the coordinates for the linestrings
+func (mlszms MultiLineStringZMS) MultiLineStringZMs() struct {
+	Srid  uint32
+	Mlszm MultiLineStringZM
+} {
+	return mlszms
+}
+
+// SetSRID modifies the struct containing the SRID int and the array of 3D+1 coordinates
+func (mlszms *MultiLineStringZMS) SetSRID(srid uint32, mlszm MultiLineStringZM) (err error) {
+	if mlszms == nil {
+		return ErrNilMultiLineStringZMS
+	}
+
+	mlszms.Srid = srid
+	mlszms.Mlszm = mlszm
+	return
+}
+
+// Get the simple 3D+1 multiline string
+func (mlszms MultiLineStringZMS) MultiLineStringZM() MultiLineStringZM {
+	return mlszms.Mlszm
+}

--- a/multi_line_stringzms_test.go
+++ b/multi_line_stringzms_test.go
@@ -16,32 +16,36 @@ func TestMultiLineStringZMSSetter(t *testing.T) {
 		expected          geom.MultiLineStringZMSSetter
 		err               error
 	}
-	fn := func(t *testing.T, tc tcase) {
-		err := tc.setter.SetSRID(tc.srid, tc.multilinestringzm)
-		if tc.err == nil && err != nil {
-			t.Errorf("error, expected nil got %v", err)
-			return
-		}
-		if tc.err != nil {
-			if tc.err.Error() != err.Error() {
-				t.Errorf("error, expected %v got %v", tc.err, err)
-			}
-			return
-		}
-		// compare the results
-		if !reflect.DeepEqual(tc.expected, tc.setter) {
-			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
-		}
 
-		mlszms := tc.setter.MultiLineStringZMs()
-		tc_mlszms := struct {
-			Srid  uint32
-			Mlszm geom.MultiLineStringZM
-		}{tc.srid, tc.multilinestringzm}
-		if !reflect.DeepEqual(tc_mlszms, mlszms) {
-			t.Errorf("Referenced MultiLineStringZM, expected %v got %v", tc_mlszms, mlszms)
+	fn := func(tc tcase) func(*testing.T) {
+		return func(t *testing.T) {
+			err := tc.setter.SetSRID(tc.srid, tc.multilinestringzm)
+			if tc.err == nil && err != nil {
+				t.Errorf("error, expected nil got %v", err)
+				return
+			}
+			if tc.err != nil {
+				if tc.err.Error() != err.Error() {
+					t.Errorf("error, expected %v got %v", tc.err, err)
+				}
+				return
+			}
+			// compare the results
+			if !reflect.DeepEqual(tc.expected, tc.setter) {
+				t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+			}
+
+			mlszms := tc.setter.MultiLineStringZMs()
+			tc_mlszms := struct {
+				Srid  uint32
+				Mlszm geom.MultiLineStringZM
+			}{tc.srid, tc.multilinestringzm}
+			if !reflect.DeepEqual(tc_mlszms, mlszms) {
+				t.Errorf("Referenced MultiLineStringZM, expected %v got %v", tc_mlszms, mlszms)
+			}
 		}
 	}
+
 	tests := []tcase{
 		{
 			srid: 4326,
@@ -87,8 +91,8 @@ func TestMultiLineStringZMSSetter(t *testing.T) {
 			err:    geom.ErrNilMultiLineStringZMS,
 		},
 	}
-	for i, tc := range tests {
-		tc := tc
-		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+
+	for i := range tests {
+		t.Run(strconv.FormatInt(int64(i), 10), fn(tests[i]))
 	}
 }

--- a/multi_line_stringzms_test.go
+++ b/multi_line_stringzms_test.go
@@ -1,0 +1,94 @@
+package geom_test
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/go-spatial/geom"
+)
+
+func TestMultiLineStringZMSSetter(t *testing.T) {
+	type tcase struct {
+		srid              uint32
+		multilinestringzm geom.MultiLineStringZM
+		setter            geom.MultiLineStringZMSSetter
+		expected          geom.MultiLineStringZMSSetter
+		err               error
+	}
+	fn := func(t *testing.T, tc tcase) {
+		err := tc.setter.SetSRID(tc.srid, tc.multilinestringzm)
+		if tc.err == nil && err != nil {
+			t.Errorf("error, expected nil got %v", err)
+			return
+		}
+		if tc.err != nil {
+			if tc.err.Error() != err.Error() {
+				t.Errorf("error, expected %v got %v", tc.err, err)
+			}
+			return
+		}
+		// compare the results
+		if !reflect.DeepEqual(tc.expected, tc.setter) {
+			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+		}
+
+		mlszms := tc.setter.MultiLineStringZMs()
+		tc_mlszms := struct {
+			Srid  uint32
+			Mlszm geom.MultiLineStringZM
+		}{tc.srid, tc.multilinestringzm}
+		if !reflect.DeepEqual(tc_mlszms, mlszms) {
+			t.Errorf("Referenced MultiLineStringZM, expected %v got %v", tc_mlszms, mlszms)
+		}
+	}
+	tests := []tcase{
+		{
+			srid: 4326,
+			multilinestringzm: geom.MultiLineStringZM{
+				{
+					{10, 20, 30, 5},
+					{30, 40, 50, 5},
+				},
+				{
+					{50, 60, 70, 5},
+					{70, 80, 90, 5},
+				},
+			},
+			setter: &geom.MultiLineStringZMS{
+				Srid: 4326,
+				Mlszm: geom.MultiLineStringZM{
+					{
+						{15, 20, 30, 5},
+						{35, 40, 50, 5},
+					},
+					{
+						{55, 60, 70, 5},
+						{75, 80, 90, 5},
+					},
+				},
+			},
+			expected: &geom.MultiLineStringZMS{
+				Srid: 4326,
+				Mlszm: geom.MultiLineStringZM{
+					{
+						{10, 20, 30, 5},
+						{30, 40, 50, 5},
+					},
+					{
+						{50, 60, 70, 5},
+						{70, 80, 90, 5},
+					},
+				},
+			},
+		},
+		{
+			setter: (*geom.MultiLineStringZMS)(nil),
+			err:    geom.ErrNilMultiLineStringZMS,
+		},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+	}
+}

--- a/multi_line_stringzs.go
+++ b/multi_line_stringzs.go
@@ -1,0 +1,36 @@
+package geom
+
+import "errors"
+
+// ErrNilMultiLineStringZS is thrown when MultiLineStringZS is nil but shouldn't be
+var ErrNilMultiLineStringZS = errors.New("geom: nil MultiLineStringZS")
+
+// MultiLineStringZS is a geometry with multiple LineStringSs.
+type MultiLineStringZS struct {
+	Srid uint32
+	Mlsz MultiLineStringZ
+}
+
+// LineStrings returns the coordinates for the linestrings
+func (mlszs MultiLineStringZS) MultiLineStringZs() struct {
+	Srid uint32
+	Mlsz MultiLineStringZ
+} {
+	return mlszs
+}
+
+// SetSRID modifies the struct containing the SRID int and the array of 3D coordinates
+func (mlszs *MultiLineStringZS) SetSRID(srid uint32, mlsz MultiLineStringZ) (err error) {
+	if mlszs == nil {
+		return ErrNilMultiLineStringZS
+	}
+
+	mlszs.Srid = srid
+	mlszs.Mlsz = mlsz
+	return
+}
+
+// Get the simple 3D multiline string
+func (mlszs MultiLineStringZS) MultiLineStringZ() MultiLineStringZ {
+	return mlszs.Mlsz
+}

--- a/multi_line_stringzs_test.go
+++ b/multi_line_stringzs_test.go
@@ -1,0 +1,94 @@
+package geom_test
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/go-spatial/geom"
+)
+
+func TestMultiLineStringZSSetter(t *testing.T) {
+	type tcase struct {
+		srid             uint32
+		multilinestringz geom.MultiLineStringZ
+		setter           geom.MultiLineStringZSSetter
+		expected         geom.MultiLineStringZSSetter
+		err              error
+	}
+	fn := func(t *testing.T, tc tcase) {
+		err := tc.setter.SetSRID(tc.srid, tc.multilinestringz)
+		if tc.err == nil && err != nil {
+			t.Errorf("error, expected nil got %v", err)
+			return
+		}
+		if tc.err != nil {
+			if tc.err.Error() != err.Error() {
+				t.Errorf("error, expected %v got %v", tc.err, err)
+			}
+			return
+		}
+		// compare the results
+		if !reflect.DeepEqual(tc.expected, tc.setter) {
+			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+		}
+
+		mlszs := tc.setter.MultiLineStringZs()
+		tc_mlszs := struct {
+			Srid uint32
+			Mlsz geom.MultiLineStringZ
+		}{tc.srid, tc.multilinestringz}
+		if !reflect.DeepEqual(tc_mlszs, mlszs) {
+			t.Errorf("Referenced MultiLineStringZ, expected %v got %v", tc_mlszs, mlszs)
+		}
+	}
+	tests := []tcase{
+		{
+			srid: 4326,
+			multilinestringz: geom.MultiLineStringZ{
+				{
+					{10, 20, 30},
+					{30, 40, 50},
+				},
+				{
+					{50, 60, 70},
+					{70, 80, 90},
+				},
+			},
+			setter: &geom.MultiLineStringZS{
+				Srid: 4326,
+				Mlsz: geom.MultiLineStringZ{
+					{
+						{15, 20, 30},
+						{35, 40, 50},
+					},
+					{
+						{55, 60, 70},
+						{75, 80, 90},
+					},
+				},
+			},
+			expected: &geom.MultiLineStringZS{
+				Srid: 4326,
+				Mlsz: geom.MultiLineStringZ{
+					{
+						{10, 20, 30},
+						{30, 40, 50},
+					},
+					{
+						{50, 60, 70},
+						{70, 80, 90},
+					},
+				},
+			},
+		},
+		{
+			setter: (*geom.MultiLineStringZS)(nil),
+			err:    geom.ErrNilMultiLineStringZS,
+		},
+	}
+	for i, tc := range tests {
+		tc := tc
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+	}
+}

--- a/multi_line_stringzs_test.go
+++ b/multi_line_stringzs_test.go
@@ -16,32 +16,36 @@ func TestMultiLineStringZSSetter(t *testing.T) {
 		expected         geom.MultiLineStringZSSetter
 		err              error
 	}
-	fn := func(t *testing.T, tc tcase) {
-		err := tc.setter.SetSRID(tc.srid, tc.multilinestringz)
-		if tc.err == nil && err != nil {
-			t.Errorf("error, expected nil got %v", err)
-			return
-		}
-		if tc.err != nil {
-			if tc.err.Error() != err.Error() {
-				t.Errorf("error, expected %v got %v", tc.err, err)
-			}
-			return
-		}
-		// compare the results
-		if !reflect.DeepEqual(tc.expected, tc.setter) {
-			t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
-		}
 
-		mlszs := tc.setter.MultiLineStringZs()
-		tc_mlszs := struct {
-			Srid uint32
-			Mlsz geom.MultiLineStringZ
-		}{tc.srid, tc.multilinestringz}
-		if !reflect.DeepEqual(tc_mlszs, mlszs) {
-			t.Errorf("Referenced MultiLineStringZ, expected %v got %v", tc_mlszs, mlszs)
+	fn := func(tc tcase) func(*testing.T) {
+		return func(t *testing.T) {
+			err := tc.setter.SetSRID(tc.srid, tc.multilinestringz)
+			if tc.err == nil && err != nil {
+				t.Errorf("error, expected nil got %v", err)
+				return
+			}
+			if tc.err != nil {
+				if tc.err.Error() != err.Error() {
+					t.Errorf("error, expected %v got %v", tc.err, err)
+				}
+				return
+			}
+			// compare the results
+			if !reflect.DeepEqual(tc.expected, tc.setter) {
+				t.Errorf("setter, expected %v got %v", tc.expected, tc.setter)
+			}
+
+			mlszs := tc.setter.MultiLineStringZs()
+			tc_mlszs := struct {
+				Srid uint32
+				Mlsz geom.MultiLineStringZ
+			}{tc.srid, tc.multilinestringz}
+			if !reflect.DeepEqual(tc_mlszs, mlszs) {
+				t.Errorf("Referenced MultiLineStringZ, expected %v got %v", tc_mlszs, mlszs)
+			}
 		}
 	}
+
 	tests := []tcase{
 		{
 			srid: 4326,
@@ -87,8 +91,8 @@ func TestMultiLineStringZSSetter(t *testing.T) {
 			err:    geom.ErrNilMultiLineStringZS,
 		},
 	}
-	for i, tc := range tests {
-		tc := tc
-		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) { fn(t, tc) })
+
+	for i := range tests {
+		t.Run(strconv.FormatInt(int64(i), 10), fn(tests[i]))
 	}
 }

--- a/set_geom.go
+++ b/set_geom.go
@@ -154,6 +154,48 @@ type MultiLineStringSetter interface {
 	SetLineStrings([][][2]float64) error
 }
 
+// MultiLineStringZSetter is a mutable MultiLineStringZer.
+type MultiLineStringZSetter interface {
+	MultiLineStringZer
+	SetLineStringZs([][][3]float64) error
+}
+
+// MultiLineStringMSetter is a mutable MultiLineStringMer.
+type MultiLineStringMSetter interface {
+	MultiLineStringMer
+	SetLineStringMs([][][3]float64) error
+}
+
+// MultiLineStringZMSetter is a mutable MultiLineZMStringer.
+type MultiLineStringZMSetter interface {
+	MultiLineStringZMer
+	SetLineStringZMs([][][4]float64) error
+}
+
+// MultiLineStringSSetter is a mutable MultiLineSStringer.
+type MultiLineStringSSetter interface {
+	MultiLineStringSer
+	SetSRID(srid uint32, mls MultiLineString) error
+}
+
+// MultiLineStringZSSetter is a mutable MultiLineZSStringer.
+type MultiLineStringZSSetter interface {
+	MultiLineStringZSer
+	SetSRID(srid uint32, mlsz MultiLineStringZ) error
+}
+
+// MultiLineStringMSSetter is a mutable MultiLineMSStringer.
+type MultiLineStringMSSetter interface {
+	MultiLineStringMSer
+	SetSRID(srid uint32, mlsm MultiLineStringM) error
+}
+
+// MultiLineStringZMSSetter is a mutable MultiLineZMSStringer.
+type MultiLineStringZMSSetter interface {
+	MultiLineStringZMSer
+	SetSRID(srid uint32, mlszm MultiLineStringZM) error
+}
+
 // PolygonSetter is a mutable Polygoner.
 type PolygonSetter interface {
 	Polygoner


### PR DESCRIPTION
The PR contains the definitions of the extended geometries for MultiLineString type. As made for the previous extended geometries, basics methods for the new types have been defined to reduce the extradimensions to 2D objects in order to be integrated with the rest of the repo.

**NOTE**: The PR contains also changes related to LineString geometries after having executed a `go fmt` command.