### PR TITLE
Add a general Marshal and Unmarshal function to geojson package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
-[![Godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/go-spatial/geom)
+[![Godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://pkg.go.dev/github.com/go-spatial/geom)
 
-# geom
+# Packages
+
+## package geom
 Geometry interfaces to help drive interoperability within the Go geospatial community. This package focuses on 2D geometries.
+
+
+## package encoding
+
+Encoding package describes a few interfaces and common errors for various sub packages implementing
+different encoders.
 
 # Dependencies
 

--- a/encoding/error.go
+++ b/encoding/error.go
@@ -6,9 +6,15 @@ import (
 	"github.com/go-spatial/geom"
 )
 
-// ErrUnknownGeometry is a wrapper around a geom.Geometry that is invalid
+// ErrUnknownGeometry is returned when a geometry type that is unknown is asked
+// to be encoded
 type ErrUnknownGeometry struct {
 	Geom geom.Geometry
+}
+
+// Error fulfills the error interface
+func (e ErrUnknownGeometry) Error() string {
+	return fmt.Sprintf("unknown geometry: %T", e.Geom)
 }
 
 // ErrInvalidGeoJSON is a wrapper around a []byte that is invalid GeoJson
@@ -16,10 +22,7 @@ type ErrInvalidGeoJSON struct {
 	GJSON []byte
 }
 
-func (e ErrUnknownGeometry) Error() string {
-	return fmt.Sprintf("unknown geometry: %T", e.Geom)
-}
-
+// Error fulfills the error interface
 func (e ErrInvalidGeoJSON) Error() string {
 	return fmt.Sprintf("Invalid GeoJSON string: %T", string(e.GJSON))
 }


### PR DESCRIPTION
The current way of using the `geojson` package requires one to wrap a geometry several times.

This PR introduces three new methods to simplify using the package.

1. `Marshal` -- which will take any geom.Geometry, or slice of geom.Geometries, or a `geojson.Feature`, or a `geojson.FeatureCollection` and return a `geojson` encoded version of it, or an error.
2. `MarshalIndent` is the same as Marshal, returning a pretty version of the output instead
3. `Unmarshal` which will take an encoded `geojson` byte slice, and return either a `geojson.Feature`, or a `geojson.FeatureCollection`.

* In addition to the above a few documentation updates, and general fixes.

@gbroccolo could you give this a review as well. Thank you.