### PR TITLE
Update tile.go to return `[]Tile` from in `FromBounds` method.

### DIFF
--- a/slippy/tile.go
+++ b/slippy/tile.go
@@ -93,8 +93,7 @@ func FromBounds(g Grid, bounds *geom.Extent, z uint) []Tile {
 		}
 	}
 
-	return nil
-
+	return ret
 }
 
 // ZXY returns back the z,x,y of the tile


### PR DESCRIPTION
The `FromBounds` was returning `nil` rather than the list of tiles it generated. This PR fixes that.