### PR TITLE
Removed rounding of UTM coordinates

### DIFF
--- a/planar/coord/utm/utm.go
+++ b/planar/coord/utm/utm.go
@@ -421,8 +421,8 @@ func fromLngLat(lnglat coord.LngLat, zone Zone, ellips coord.Ellipsoid) Coord {
 		digraph, _ = newDigraph(zone, lnglat)
 	}
 	return Coord{
-		Northing: math.Round(northing),
-		Easting:  math.Round(easting),
+		Northing: northing,
+		Easting:  easting,
 		Zone:     zone,
 		Digraph:  digraph,
 	}


### PR DESCRIPTION
Fix for #119

The rounding to the desired precision depends on the application, so I believe it's better to leave it out of the UTM conversion.