### PR TITLE
[#118] When unmarshalling geojson the system was not checking for keys

### DIFF
--- a/encoding/geojson/errros.go
+++ b/encoding/geojson/errros.go
@@ -1,0 +1,19 @@
+package geojson
+
+import (
+	"fmt"
+)
+
+type ErrMissingField string
+
+func (err ErrMissingField) Error() string {
+	return fmt.Sprintf("missing geojson field '%v'", string(err))
+}
+
+func (err ErrMissingField) Is(target error) bool {
+	mf, ok := target.(ErrMissingField)
+	if !ok {
+		return false
+	}
+	return string(mf) == string(err)
+}


### PR DESCRIPTION
When unmarshalling geojson the system was assuming that certain keys just existed; this cause
a panic when those keys did not exist.

Now the system will check for the existence of the key and return and error if the keys don't
exist.

* minor lint cleanup as well.

fixes #118